### PR TITLE
feature(asserts): Adds asserts and other strippable debug helpers

### DIFF
--- a/addon/-debug/helpers.js
+++ b/addon/-debug/helpers.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+const {
+  warn: emberWarn,
+  deprecate: emberDeprecate,
+  Logger
+} = Ember;
+
+export function debug() {
+  Logger.debug(...arguments);
+}
+
+export function debugOnError(msg, conditional) {
+  if (!conditional) {
+    console.error(msg); // eslint-disable-line no-console
+    debugger; // eslint-disable-line no-debugger
+  }
+}
+
+export function assert(msg, conditional) {
+  if (!conditional) {
+    throw new Error(msg);
+  }
+}
+
+export function warn() {
+  emberWarn(...arguments);
+}
+
+export function deprecate() {
+  emberDeprecate(...arguments);
+}
+
+export function stripInProduction(cb) {
+  cb();
+}

--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { assert } from '../-debug/helpers';
 //import Popper from 'popper.js';
 
 export default Ember.Component.extend({
@@ -38,9 +39,15 @@ export default Ember.Component.extend({
     // If there is no target, set the target to the parent element
     if (!target) {
       return this.element.parentNode;
-    }
+    } else if (target instanceof Element) {
+      return target;
+    } else {
+      const nodes = document.querySelectorAll(target);
 
-    return (target instanceof Element) ? target : document.querySelectorAll(target)[0];
+      assert(`ember-popper with target selector "${target}" found ${nodes.length} possible targets when there should be exactly 1`, nodes.length === 1);
+
+      return nodes[0];
+    }
   }),
 
   popperDidChange: Ember.observer(

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 /* eslint-env node */
 'use strict';
 
+var StripClassCallCheck = require('babel6-plugin-strip-class-callcheck');
+var FilterImports = require('babel-plugin-filter-imports');
+var RemoveImports = require('./lib/babel-plugin-remove-imports');
+var Funnel = require('broccoli-funnel');
+
 module.exports = {
   name: 'ember-popper',
 
@@ -8,8 +13,55 @@ module.exports = {
     nodeAssets: {
       'popper.js': {
         srcDir: 'dist',
-        import: ['popper.js']
+        import: ['popper.es5.js']
       }
     }
+  },
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+
+    this._env = app.env;
+    this._setupBabelOptions(app.env);
+  },
+
+  _hasSetupBabelOptions: false,
+  _setupBabelOptions: function(env) {
+    if (this._hasSetupBabelOptions) {
+      return;
+    }
+
+    if (/production/.test(env) || /test/.test(env)) {
+      var strippedImports = {
+        'ember-popper/-debug/helpers': [
+          'assert',
+          'warn',
+          'debug',
+          'debugOnError',
+          'deprecate',
+          'stripInProduction'
+        ]
+      };
+
+      this.options.babel = {
+        plugins: [
+          [FilterImports, strippedImports],
+          [RemoveImports, 'ember-popper/-debug/helpers']
+        ],
+        postTransformPlugins: [StripClassCallCheck]
+      };
+    }
+
+    this._hasSetupBabelOptions = true;
+  },
+
+  treeForAddon: function() {
+    var tree = this._super.treeForAddon.apply(this, arguments);
+
+    if (/production/.test(this._env) || /test/.test(this._env)) {
+      tree = new Funnel(tree, { exclude: [ /-debug/ ] });
+    }
+
+    return tree;
   }
 };

--- a/lib/babel-plugin-remove-imports.js
+++ b/lib/babel-plugin-remove-imports.js
@@ -1,0 +1,40 @@
+var path = require('path');
+
+function removeImports() {
+  let importDeclarationsToRemove;
+  let filteredImports;
+
+  return {
+    name: 'remove-filtered-imports',
+    visitor: {
+      Program: {
+        enter: function(_, state) {
+          filteredImports = state.opts instanceof Array ? state.opts : (state.opts ? [state.opts] : []);
+          importDeclarationsToRemove = [];
+        },
+        exit: function() {
+          importDeclarationsToRemove.forEach(function(declaration) {
+            declaration.remove();
+          });
+
+          importDeclarationsToRemove = undefined;
+        }
+      },
+
+      ImportDeclaration: function(path) {
+        const name = path.node.source.value;
+
+        if (filteredImports.indexOf(name) !== -1) {
+          importDeclarationsToRemove.push(path);
+        }
+      }
+
+    }
+  };
+}
+
+removeImports.baseDir = function() {
+  return path.join(__dirname, '../');
+};
+
+module.exports = removeImports;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.0.0-beta.9",
+    "babel-plugin-filter-imports": "^0.3.1",
+    "babel6-plugin-strip-class-callcheck": "^6.0.0",
+    "broccoli-funnel": "^1.0.7",
     "ember-cli-node-assets": "^0.1.6",
     "popper.js": "^1.0.8"
   },
@@ -35,7 +38,7 @@
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
     "ember-cli-shims": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,9 +448,13 @@ babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
 
-babel-plugin-htmlbars-inline-precompile@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.1.0.tgz#b784723bd1f108796b56faf9f1c05eb5ca442983"
+babel-plugin-filter-imports@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
+
+babel-plugin-htmlbars-inline-precompile@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz#cd365e278af409bfa6be7704c4354beee742446b"
 
 babel-plugin-inline-environment-variables@^1.0.1:
   version "1.0.1"
@@ -807,6 +811,10 @@ babel-types@^6.19.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel6-plugin-strip-class-callcheck@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-class-callcheck/-/babel6-plugin-strip-class-callcheck-6.0.0.tgz#de841c1abebbd39f78de0affb2c9a52ee228fddf"
+
 babylon@^5.8.38:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
@@ -971,18 +979,6 @@ broccoli-babel-transpiler@^6.0.0:
     hash-for-dep "^1.0.2"
     json-stable-stringify "^1.0.0"
 
-broccoli-babel-transpiler@^6.0.0-alpha.3:
-  version "6.0.0-alpha.3"
-  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.0.0-alpha.3.tgz#4c46c800753242cc4109c44700db63dc3862d7d0"
-  dependencies:
-    babel-core "^6.14.0"
-    broccoli-funnel "^1.0.0"
-    broccoli-merge-trees "^1.0.0"
-    broccoli-persistent-filter "^1.0.1"
-    clone "^2.0.0"
-    hash-for-dep "^1.0.2"
-    json-stable-stringify "^1.0.0"
-
 broccoli-brocfile-loader@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/broccoli-brocfile-loader/-/broccoli-brocfile-loader-0.18.0.tgz#2e86021c805c34ffc8d29a2fb721cf273e819e4b"
@@ -1070,7 +1066,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.0.7:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.1.0.tgz#dfb91a37c902456456de4a40a1881948d65b27d9"
   dependencies:
@@ -1190,7 +1186,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.4.0.tgz#1bdb0a1804d62a419d190abc26acb3c91878154d"
   dependencies:
@@ -1769,7 +1765,7 @@ ember-ajax@^2.4.1:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7, ember-cli-babel@^5.2.1:
+ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -1779,7 +1775,7 @@ ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0-beta.7:
+ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9:
   version "6.0.0-beta.9"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.0.0-beta.9.tgz#b597d52f12d4429cd5716b55f749ebf6144b7b16"
   dependencies:
@@ -1828,16 +1824,15 @@ ember-cli-get-dependency-depth@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz#e0afecf82a2d52f00f28ab468295281aec368d11"
 
-ember-cli-htmlbars-inline-precompile@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.3.6.tgz#4095fe423f93102724c0725e4dd1a31f25e24de5"
+ember-cli-htmlbars-inline-precompile@^0.4.0-beta.2:
+  version "0.4.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.4.0-beta.2.tgz#2ecb78ea1aaa14dd75300e3856c10c7e309209f6"
   dependencies:
-    babel-plugin-htmlbars-inline-precompile "^0.1.0"
-    ember-cli-babel "^5.1.3"
-    ember-cli-htmlbars "^1.0.0"
+    babel-plugin-htmlbars-inline-precompile "^0.2.3"
+    ember-cli-version-checker "^1.2.0"
     hash-for-dep "^1.0.2"
 
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
+ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.2.0.tgz#327e1a5dda1c85c6fcf8be888f7894b32c3f393b"
   dependencies:


### PR DESCRIPTION
And adds an assert to `ember-popper` if a selector selects more than one node (or no nodes at all).

Also, changes the Popper import to the es5 build because of this bug caused by uglify on production builds: https://github.com/mishoo/UglifyJS2/issues/448