### PR TITLE
fix(z-index issues) render poppers in the body by default

### DIFF
--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -1,8 +1,23 @@
 import Ember from 'ember';
+import layout from '../templates/components/ember-popper';
 import { assert } from '../-debug/helpers';
 
+
 export default Ember.Component.extend({
+
+  /**
+   * ================== PUBLIC CONFIG OPTIONS ==================
+   */
+
+  options: null,
+  popperClass: null,
+  popperContainer: document.body,
+  renderInPlace: false,
   target: null,
+
+  /**
+   * ================== LIFECYCLE HOOKS ==================
+   */
 
   init() {
     this._super(...arguments);
@@ -15,24 +30,51 @@ export default Ember.Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    this.addPopper();
+    this._addPopper();
   },
 
   willDestroyElement() {
     this._super(...arguments);
 
-    Ember.run.schedule('render', () => {
-      this._popper.destroy();
-    });
+    this._popper.destroy();
   },
 
-  addPopper() {
-    if (this.element) {
-      this._popper = new Popper(this.get('_popperTarget'), this.element, this.get('options'));
+  /**
+   * ================== PRIVATE IMPLEMENTATION DETAILS ==================
+   */
+
+  classNameBindings: ['_popperClass'],
+  layout,
+  isVisible: Ember.computed(function() {
+    return this.get('renderInPlace')
+  }),
+
+  // set in didInsertElement() once the Popper is initialized. Passed to consumers via  anamed yield
+  _popper: null,
+  _popperClass: Ember.computed(function() {
+    if (this.get('renderInPlace')) {
+      return this.get('popperClass');
+    } else {
+      return false;
     }
+  }),
+  // set in didInsertElement() once the Popper is initialized. Passed to consumers via  anamed yield
+  _popperTarget: null,
+
+  _addPopper() {
+    let popperTarget = this.set('_popperTarget', this._getPopperTarget());
+
+    this.set('_popper', new Popper(popperTarget,
+                                  this.get('_popperElement'),
+                                  this.get('options')));
   },
 
-  _popperTarget: Ember.computed('target', function() {
+  /**
+   * This is a function so it can be called after elements have been rendered.
+   * If set to a computed property, it is called too early b/c of the named yield for popperTarget.
+   * In this case, the target might be a selector but the element may not yet exist.
+   */
+  _getPopperTarget() {
     let target = this.get('target');
 
     // If there is no target, set the target to the parent element
@@ -43,19 +85,40 @@ export default Ember.Component.extend({
     } else {
       const nodes = document.querySelectorAll(target);
 
-      assert(`ember-popper with target selector "${target}" found ${nodes.length} possible targets when there should be exactly 1`, nodes.length === 1);
+      assert(`ember-popper with target selector "${target}" found ${nodes.length}`
+             + 'possible targets when there should be exactly 1', nodes.length === 1);
 
       return nodes[0];
     }
+  },
+
+  _popperElement: Ember.computed('renderInPlace', function() {
+    if (this.get('renderInPlace')) {
+      return this.element;
+    } else {
+      return document.querySelector(`.popper-${this.elementId}`);
+    }
   }),
 
+  // This will be used to support Ember versions before Glimmer 2.0
+  _moveElementToBody() {
+    if (this.element.parentNode !== document.body) {
+      document.body.appendChild(this.element);
+    }
+  },
+
+  // This will be used to support Ember versions before Glimmer 2.0
+  _destroyElementIfMovedToBody() {
+    this.element.parentNode.removeChild(this.element);
+  },
+
   popperDidChange: Ember.observer(
-    'target',
     'options',
+    'target',
     function() {
       this._popper.destroy();
 
-      this.addPopper();
+      this._addPopper();
     }
   ),
 });

--- a/addon/templates/components/ember-popper.hbs
+++ b/addon/templates/components/ember-popper.hbs
@@ -1,0 +1,9 @@
+{{#if renderInPlace}}
+  {{yield (hash popper=_popper popperTarget=_popperTarget popperElement=_popperElement)}}
+{{else}}
+  {{#-in-element popperContainer}}
+    <div class="popper-{{elementId}} {{popperClass}}">
+      {{yield (hash popper=_popper popperTarget=_popperTarget popperElement=_popperElement)}}
+    </div>
+  {{/-in-element}}
+{{/if}}

--- a/app/templates/components/ember-popper.js
+++ b/app/templates/components/ember-popper.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-popper/templates/components/ember-popper';

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "license": "MIT",
   "author": {
-    "name" : "Kyle Bishop",
-    "email" : "kybishop@gmail.com",
-    "url" : "http://kybishop.com"
+    "name": "Kyle Bishop",
+    "email": "kybishop@gmail.com",
+    "url": "http://kybishop.com"
   },
   "directories": {
     "doc": "doc",
@@ -24,12 +24,13 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.0.0-beta.9",
     "babel-plugin-filter-imports": "^0.3.1",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-funnel": "^1.0.7",
+    "ember-cli-babel": "^6.0.0-beta.9",
+    "ember-cli-htmlbars": "^1.3.0",
     "ember-cli-node-assets": "^0.1.6",
-    "popper.js": "^1.8.2"
+    "popper.js": "^1.9.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -37,7 +38,6 @@
     "ember-cli": "2.12.1",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
-    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,11 +1,19 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  showTargetedPopper: true,
+
   popperOptions: {
     modifiers: {
       flip: {
         behavior: ['left', 'right', 'bottom']
       }
+    }
+  },
+
+  actions: {
+    toggleShowTargetedPopper() {
+      this.toggleProperty('showTargetedPopper');
     }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,10 +1,10 @@
 <div class="row">
   <div class="left">
-    {{#ember-popper class="popper"}}
+    {{#ember-popper popperClass="popper"}}
       Hello from the left! I have no explicit target.
       <div class="popper-arrow" x-arrow></div>
 
-      {{#ember-popper class="popper"}}
+      {{#ember-popper popperClass="popper"}}
         <span style="white-space: nowrap">P O P P E R C E P T I O N</span>
         <br>
         I also have no explicit target,
@@ -17,9 +17,13 @@
   <div class="right"></div>
 </div>
 
-{{#ember-popper class="popper" target=".right" options=popperOptions}}
-  Hello from the right!
-  <br>
-  I explicitly target the right div
-  <div class="popper-arrow" x-arrow></div>
-{{/ember-popper}}
+{{#if showTargetedPopper}}
+  {{#ember-popper popperClass="popper" target=".right" options=popperOptions}}
+    Hello from the right!
+    <br>
+    I explicitly target the right div
+    <div class="popper-arrow" x-arrow></div>
+  {{/ember-popper}}
+{{/if}}
+
+<button {{action "toggleShowTargetedPopper"}}>toggle show targeted popper</button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4130,9 +4130,9 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-popper.js@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.8.2.tgz#c6256b39dc20b3da58f0f2231407b126da017d40"
+popper.js@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.9.1.tgz#aedce56910172595e30aa7f33a1ede72e00d172c"
 
 portfinder@^1.0.7:
   version "1.0.13"


### PR DESCRIPTION
CONTEXT: rendering the popper in place causes z-index issues where elements in the same level as the popper's parent, or elements further down the dom tree, overlap the popper. We can skirt this issue by simply moving the popper to the body. Luckily, there is a way to do this natively in Glimmer 2.0. Pre Glimmer-2.0 support is planned in the near future.

Side-note: By explicitly exposing the poppers through a named yield, I'm able to use an `{{#ember-popper}}` in ember-attacher's template without having to extend/subclass ember-popper, works out quite elegantly.