### PR TITLE
fix(popper recreation) wait until the element has rerendered

### DIFF
--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -144,7 +144,9 @@ export default Ember.Component.extend({
     function() {
       this._popper.destroy();
 
-      this._addPopper();
+      Ember.run.next(() => {
+        this._addPopper();
+      });
     }
   ),
 });


### PR DESCRIPTION
If one of the properties changes that requires that the `Popper` instance to be recreated, we need to wait until the element has been re-rendered before we can create the new instance.