### PR TITLE
FastBoot compatibility

### DIFF
--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
 
   // The popper element needs to be moved higher in the DOM tree to avoid z-index issues.
   // See the block-comment in the template for more details.
-  popperContainer: document.body,
+  popperContainer: self.document ? self.document.body : '',
 
   // If `true`, the popper element will not be moved to popperContainer. WARNING: This can cause
   // z-index issues where your popper will be overlapped by DOM elements that aren't nested as

--- a/index.js
+++ b/index.js
@@ -9,16 +9,6 @@ const Funnel = require('broccoli-funnel');
 module.exports = {
   name: 'ember-popper',
 
-  options: {
-    nodeAssets: {
-      'popper.js': {
-        srcDir: 'dist/umd',
-        import: ['popper.js'],
-        vendor: ['popper.js.map']
-      }
-    }
-  },
-
   included: function(app) {
     this._super.included.apply(this, arguments);
 

--- a/index.js
+++ b/index.js
@@ -5,12 +5,16 @@ const StripClassCallCheck = require('babel6-plugin-strip-class-callcheck');
 const FilterImports = require('babel-plugin-filter-imports');
 const RemoveImports = require('./lib/babel-plugin-remove-imports');
 const Funnel = require('broccoli-funnel');
+const path = require('path');
+const map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'ember-popper',
 
   included: function(app) {
     this._super.included.apply(this, arguments);
+
+    app.import('vendor/popper.js');
 
     this._env = app.env;
     this._setupBabelOptions(app.env);
@@ -54,5 +58,18 @@ module.exports = {
     }
 
     return tree;
+  },
+
+  treeForVendor: function() {
+    var popperTree = new Funnel(path.join(this.project.root, 'node_modules', 'popper.js'), {
+      srcDir: 'dist/umd',
+      files: ['popper.js', 'popper.js.map']
+    });
+
+    popperTree = map(popperTree, function(content) {
+      return `if (typeof FastBoot === 'undefined') { ${content} }`;
+    });
+
+    return popperTree;
   }
 };

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "broccoli-funnel": "^1.0.7",
     "ember-cli-babel": "^6.1.0",
     "ember-cli-htmlbars": "^1.3.3",
-    "ember-cli-node-assets": "^0.2.2",
     "popper.js": "^1.9.8"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "broccoli-stew": "^1.5.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.13.2",
     "ember-cli-dependency-checker": "^1.3.0",

--- a/tests/integration/components/ember-popper-test.js
+++ b/tests/integration/components/ember-popper-test.js
@@ -5,18 +5,15 @@ moduleForComponent('ember-popper', 'Integration | Component | ember popper', {
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders in place', function(assert) {
+  assert.expect(2);
 
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
-  this.render(hbs`{{ember-popper}}`);
+  this.render(hbs`{{ember-popper renderInPlace=true}}`);
 
   assert.equal(this.$().text().trim(), '');
 
-  // Template block usage:
   this.render(hbs`
-    {{#ember-popper}}
+    {{#ember-popper renderInPlace=true}}
       template block text
     {{/ember-popper}}
   `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,7 +1221,7 @@ broccoli-lint-eslint@^3.3.0:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.4:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1304,7 +1304,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2005,17 +2005,6 @@ ember-cli-legacy-blueprints@^0.1.2:
 ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
-
-ember-cli-node-assets@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-source "^1.1.0"
-    debug "^2.2.0"
-    lodash "^4.5.1"
-    resolve "^1.1.7"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -3780,7 +3769,7 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Add support for [ember-cli-fastboot](https://ember-fastboot.com).

- Guard against global objects that aren't available in Node.js, e.g. `document` and `document.body`.
- Disable incompatible `popper.js` dependency when in the FastBoot environment.
- Fix component integration test by rendering in place.
- Verified integration tests with and without `ember-cli-fastboot`.