### PR TITLE
Fix broken build for consuming apps on ember-cli 2.10-2.13 when in test or prod mode

### DIFF
--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/ember-popper';
-import { assert } from '../-debug/helpers';
+import { assert } from 'ember-popper/-debug/helpers';
 
 
 export default Ember.Component.extend({

--- a/index.js
+++ b/index.js
@@ -50,6 +50,9 @@ module.exports = {
         ]
       };
 
+      // In some versions of Ember, this.options is undefined during tests
+      this.options = this.options || {};
+
       this.options.babel = {
         plugins: [
           [FilterImports, strippedImports],


### PR DESCRIPTION
Absolute paths are needed for dev-only imports because of the way we strip them in prod/test mode. This caused prod and test builds to fail in consuming apps using ember-cli 2.10 to 2.13. `#shame` `#sorry`. I believe 2.14 is still working because of fancy new dead-code elimination, which strips the import for us.

In addition, `this.options` in ember-popper's index.js is, for reasons not known to me, `undefined` when the consuming app is running tests with ember 2.10 (and possibly other versions of ember before 2.13).

These bugs are tricky to test because the dummy app and addon tests both work just fine regardless of either 🤔 