### PR TITLE
fix(renderInPlace) allow renderInplace to be false in fastboot

### DIFF
--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -49,20 +49,10 @@ export default Ember.Component.extend({
   // If `true`, the popper element will not be moved to popperContainer. WARNING: This can cause
   // z-index issues where your popper will be overlapped by DOM elements that aren't nested as
   // deeply in the DOM tree.
-  renderInPlace: Ember.computed({
-    set(_, value) {
-      // self.document is undefined in Fastboot, so we always render in place when it is undefined.
-      if (self.document) {
-        return value;
-      }
-
-      return true;
-    },
-
-    get() {
-      // self.document is undefined in Fastboot, so we always render in place when it is undefined.
-      return self.document ? false : true;
-    }
+  renderInPlace: Ember.computed(function() {
+    // self.document is undefined in Fastboot, so we have to render in place for the popper to show
+    // up at all.
+    return self.document ? false : true;
   }),
 
   // The element the popper will target. If left blank, will be set to the ember-popper's parent.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,10 +6,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
-    fingerprint: {
-      enabled: true,
-      generateAssetMap: true
-    }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-cli": "~2.14.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
-    "ember-cli-fastboot": "^1.0.0-rc.5",
+    "ember-cli-fastboot": "1.0.0-rc.5",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,9 +2019,9 @@ ember-cli-eslint@^3.0.0:
     rsvp "^3.2.1"
     walk-sync "^0.3.0"
 
-ember-cli-fastboot@^1.0.0-rc.5:
-  version "1.0.0-rc3"
-  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-1.0.0-rc3.tgz#971179bdb8f53215025dd23b2f18765b63008584"
+ember-cli-fastboot@1.0.0-rc.5:
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-1.0.0-rc.5.tgz#4f1a5919f1c6bf00850c8412669510fe642b77c3"
   dependencies:
     broccoli-concat "^3.2.2"
     broccoli-funnel "^1.2.0"


### PR DESCRIPTION
Since `false` is already the default, you probably have a reason for explicitly setting `renderInPlace` to `false`. Also, depending on how CSS for the popper is set up, rendering in place can cause the page to look funny while the real app loads in the background (example being a bunch of normally rendered on the body poppers being positioned in the top left of the screen).