### PR TITLE
bugfix(update/id): Makes id work and less aggressively updates

### DIFF
--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -1,19 +1,21 @@
+import Ember from 'ember';
 import EmberPopperBase from './ember-popper-base';
+
+const { generateGuid } = Ember;
 
 export default class EmberPopper extends EmberPopperBase {
 
   // ================== LIFECYCLE HOOKS ==================
 
   init() {
-    this._popperClass = this.get('class');
+    this.id = this.id || generateGuid();
+    this._parentFinder = self.document ? self.document.createTextNode('') : '';
 
     super.init(...arguments);
   }
 
   didInsertElement() {
-    if (this.get('_renderInPlace') === false) {
-      this.element.className = '';
-    }
+    this._initialParentNode = this._parentFinder.parentNode;
 
     super.didInsertElement(...arguments);
   }

--- a/addon/templates/components/-ember-popper-legacy.hbs
+++ b/addon/templates/components/-ember-popper-legacy.hbs
@@ -1,5 +1,5 @@
 {{yield (hash
-  update=(action 'update')
+  scheduleUpdate=(action 'scheduleUpdate')
   enableEventListeners=(action 'enableEventListeners')
   disableEventListeners=(action 'disableEventListeners')
 )}}

--- a/addon/templates/components/ember-popper.hbs
+++ b/addon/templates/components/ember-popper.hbs
@@ -1,9 +1,13 @@
+{{unbound _parentFinder}}
+
 {{#if renderInPlace}}
-  {{yield (hash
-    update=(action 'update')
-    enableEventListeners=(action 'enableEventListeners')
-    disableEventListeners=(action 'disableEventListeners')
-  )}}
+  <div id={{id}} class={{class}}>
+    {{yield (hash
+      scheduleUpdate=(action 'scheduleUpdate')
+      enableEventListeners=(action 'enableEventListeners')
+      disableEventListeners=(action 'disableEventListeners')
+    )}}
+  </div>
 {{else}}
   {{!-- Elements that exist deep within the document tree are given an implicitly lower z-index
         value than elements that aren't as deep in the tree; this has the effect of hiding our
@@ -13,9 +17,9 @@
 
   {{#-in-element _popperContainer}}
     {{!-- Add a wrapper around the yielded block so we have something for the Popper to target --}}
-    <div class="popper-{{elementId}} {{_popperClass}}">
+    <div id={{id}} class={{class}}>
       {{yield (hash
-        update=(action 'update')
+        scheduleUpdate=(action 'scheduleUpdate')
         enableEventListeners=(action 'enableEventListeners')
         disableEventListeners=(action 'disableEventListeners')
       )}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,11 +6,11 @@ module.exports = {
       bower: {
         dependencies: {
           'ember': '~1.11.0',
-          'ember-cli-shims': 'ember-cli/ember-cli-shims#0.0.3'
+          'ember-cli-shims': '0.0.6'
         },
         resolutions: {
           'ember': '~1.11.0',
-          'ember-cli-shims': '0.0.3'
+          'ember-cli-shims': '0.0.6'
         }
       },
       npm: {

--- a/index.js
+++ b/index.js
@@ -24,10 +24,16 @@ module.exports = {
     }
   },
 
-  included(app) {
+  included(parent) {
     this._super.included.apply(this, arguments);
 
-    const checker = new VersionChecker(this);
+    let app = parent;
+
+    while (!app.import) {
+      app = app.parent;
+    }
+
+    const checker = new VersionChecker(app);
 
     this._emberChecker = checker.forEmber();
     this._env = app.env;

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-funnel": "^1.0.7",
     "ember-cli-babel": "^6.3.0",
-    "ember-cli-htmlbars": "^1.3.3",
+    "ember-cli-htmlbars": "^2.0.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-decorators": "^1.2.0",
     "fastboot-transform": "^0.1.0",
+    "ember-cli-version-checker": "^2.0.0",
     "popper.js": "^1.10.8"
   },
   "devDependencies": {
@@ -48,7 +49,6 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-cli-version-checker": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-hash-helper-polyfill": "^0.1.2",

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,6 +14,19 @@
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
+    <style>
+      #ember-testing {
+        transform: none;
+        width: 100%;
+        height: 100%;
+      }
+
+      #ember-testing-container {
+        width: 1000px;
+        height: 1000px;
+      }
+    </style>
+
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>

--- a/tests/integration/components/ember-popper/attributes-test.js
+++ b/tests/integration/components/ember-popper/attributes-test.js
@@ -1,0 +1,31 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { find } from 'ember-native-dom-helpers';
+
+moduleForComponent('ember-popper', 'Integration | Component | attributes', {
+  integration: true
+});
+
+test('id is bound correctly', function(assert) {
+  this.render(hbs`
+    <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100%;'>
+      {{#ember-popper placement='top' id='foo'}}
+        test
+      {{/ember-popper}}
+    </div>
+  `);
+
+  assert.ok(find('#foo'), 'id attribute bound correctly');
+});
+
+test('class is bound correctly', function(assert) {
+  this.render(hbs`
+    <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100%;'>
+      {{#ember-popper placement='top' class='foo'}}
+        test
+      {{/ember-popper}}
+    </div>
+  `);
+
+  assert.ok(find('.foo'), 'class attribute bound correctly');
+});

--- a/tests/integration/components/ember-popper/events-enabled-test.js
+++ b/tests/integration/components/ember-popper/events-enabled-test.js
@@ -9,12 +9,12 @@ moduleForComponent('ember-popper', 'Integration | Component | eventsEnabled', {
 
 test('sets eventsEnabled in the Popper instance', function(assert) {
   this.render(hbs`
-    <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100vw;'>
-      {{#ember-popper placement='top' class='events-enabled'}}
+    <div class='parent' style='height: 100px; width: 100%;'>
+      {{#ember-popper placement='bottom' class='events-enabled'}}
         eventsEnabled test
       {{/ember-popper}}
 
-      {{#ember-popper eventsEnabled=false placement='top' class='events-disabled'}}
+      {{#ember-popper eventsEnabled=false placement='bottom' class='events-disabled'}}
         eventsEnabled test
       {{/ember-popper}}
     </div>
@@ -25,15 +25,15 @@ test('sets eventsEnabled in the Popper instance', function(assert) {
   const eventsDisabledPopper = document.querySelector('.events-disabled');
 
   return wait().then(() => {
-    const initialTopOfParent = parent.getBoundingClientRect().top;
-    const eventsEnabledInitialPosition = eventsEnabledPopper.getBoundingClientRect().bottom;
-    const eventsDisabledInitialPosition = eventsDisabledPopper.getBoundingClientRect().bottom;
+    const initialBottomOfParent = parent.getBoundingClientRect().bottom;
+    const eventsEnabledInitialPosition = eventsEnabledPopper.getBoundingClientRect().top;
+    const eventsDisabledInitialPosition = eventsDisabledPopper.getBoundingClientRect().top;
 
     // Sanity check
-    assert.equal(initialTopOfParent,
+    assert.equal(initialBottomOfParent,
                  eventsEnabledInitialPosition,
                  'initial eventsEnabled position is correct');
-    assert.equal(initialTopOfParent,
+    assert.equal(initialBottomOfParent,
                  eventsDisabledInitialPosition,
                  'initial eventsDisabled position is correct');
 
@@ -43,13 +43,13 @@ test('sets eventsEnabled in the Popper instance', function(assert) {
 
     return wait().then(() => {
       // Sanity check
-      assert.notEqual(initialTopOfParent, parent.getBoundingClientRect().top, 'the parent moved');
+      assert.notEqual(initialBottomOfParent, parent.getBoundingClientRect().bottom, 'the parent moved');
 
-      assert.equal(eventsEnabledPopper.getBoundingClientRect().bottom,
-                   parent.getBoundingClientRect().top,
+      assert.equal(eventsEnabledPopper.getBoundingClientRect().top,
+                   parent.getBoundingClientRect().bottom,
                    'events enabled poppers move on scroll');
 
-      assert.equal(eventsDisabledPopper.getBoundingClientRect().bottom,
+      assert.equal(eventsDisabledPopper.getBoundingClientRect().top,
                    eventsDisabledInitialPosition,
                    "events not enabled poppers don't move on scroll");
     });

--- a/tests/integration/components/ember-popper/render-in-place-test.js
+++ b/tests/integration/components/ember-popper/render-in-place-test.js
@@ -20,7 +20,7 @@ test('false: renders in the body', function(assert) {
   assert.equal(popper.innerHTML.trim(), 'template block text');
   assert.ok(popper.hasAttribute('x-placement'));
 
-  assert.equal(popper.parentElement, document.body);
+  assert.equal(popper.parentElement, document.querySelector('.ember-application'));
 });
 
 test('false with an explicit popperContainer: renders in the popperContainer', function(assert) {

--- a/tests/integration/components/ember-popper/target-test.js
+++ b/tests/integration/components/ember-popper/target-test.js
@@ -8,8 +8,8 @@ moduleForComponent('ember-popper', 'Integration | Component | target', {
 
 test('undefined target: it targets the parent', function(assert) {
   this.render(hbs`
-    <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100vw;'>
-      {{#ember-popper class='popper-element' placement='top'}}
+    <div class='parent' style='height: 50px; width: 100%;'>
+      {{#ember-popper class='popper-element' placement='bottom'}}
         template block text
       {{/ember-popper}}
     </div>
@@ -19,15 +19,15 @@ test('undefined target: it targets the parent', function(assert) {
   const popper = document.querySelector('.popper-element');
 
   return wait().then(() => {
-    assert.equal(parent.getBoundingClientRect().top,
-                 popper.getBoundingClientRect().bottom);
+    assert.equal(parent.getBoundingClientRect().bottom,
+                 popper.getBoundingClientRect().top);
 
   });
 });
 
 test('explicit target: it targets the explicit target', function(assert) {
   this.render(hbs`
-    <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100vw;'>
+    <div class='parent' style='height: 50px; width: 100%;'>
     </div>
 
     {{#ember-popper class='popper-element' placement='top' target='.parent'}}
@@ -39,8 +39,8 @@ test('explicit target: it targets the explicit target', function(assert) {
   const popper = document.querySelector('.popper-element');
 
   return wait().then(() => {
-    assert.equal(parent.getBoundingClientRect().top,
-                 popper.getBoundingClientRect().bottom);
+    assert.equal(parent.getBoundingClientRect().bottom,
+                 popper.getBoundingClientRect().top);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,15 +2092,14 @@ ember-cli-htmlbars-inline-precompile@^0.4.3:
     hash-for-dep "^1.0.2"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.3.tgz#06815262c1577736235bd42ce99db559ce5ebfd1"
+ember-cli-htmlbars@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.2.tgz#230a9ace7c3454b3acff2768a50f963813a90c38"
   dependencies:
     broccoli-persistent-filter "^1.0.3"
-    ember-cli-version-checker "^1.0.2"
     hash-for-dep "^1.0.2"
     json-stable-stringify "^1.0.0"
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
 
 ember-cli-inject-live-reload@^1.4.1:
   version "1.6.1"
@@ -3623,10 +3622,6 @@ is-type@0.0.1:
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
 is-windows@^0.2.0:
   version "0.2.0"
@@ -5215,12 +5210,6 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  dependencies:
-    is-utf8 "^0.2.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
So there were some structural problems with the last cut:

* binding `id` didn't work in modern ember versions but did in legacy. Given it's pretty useful, it should likely be preserved.
* we updated the popper way too eagerly. A change in a class name would cause the popper to update, which could cause all kinds of havoc.
* `ember-native-dom-helpers` wouldn't work since we didn't attach to the app context (`.ember-application`)

This refactor makes the modern version of popper tagless, and uses some tricks to keep the context. It also stores all of the elements that make a popper (options, element, target) to compare to updated attributes. Finally, updated tests to work inside the testing container, making them less brittle overall.