### PR TITLE
feat(yield popper target as 'target')

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -150,7 +150,7 @@ export default class EmberPopperBase extends Component {
 
     // Compare against previous values to see if anything has changed
     const didChange = renderInPlace !== this._didRenderInPlace
-      || popperTarget !== this._popperTarget
+      || popperTarget !== this.get('_popperTarget')
       || eventsEnabled !== this._eventsEnabled
       || modifiers !== this._modifiers
       || placement !== this._placement;
@@ -164,10 +164,11 @@ export default class EmberPopperBase extends Component {
 
       // Store current values to check against on updates
       this._didRenderInPlace = renderInPlace;
-      this._popperTarget = popperTarget;
       this._eventsEnabled = eventsEnabled;
       this._modifiers = modifiers;
       this._placement = placement;
+      // NOTE: This property is yielded, so we have to use set to notify of a change
+      this.set('_popperTarget', popperTarget);
 
       this._popper = new Popper(popperTarget, popperElement, { eventsEnabled, modifiers, placement });
     }

--- a/addon/templates/components/-ember-popper-legacy.hbs
+++ b/addon/templates/components/-ember-popper-legacy.hbs
@@ -1,6 +1,7 @@
 {{yield (hash
-  update=(action 'update')
-  scheduleUpdate=(action 'scheduleUpdate')
-  enableEventListeners=(action 'enableEventListeners')
   disableEventListeners=(action 'disableEventListeners')
+  enableEventListeners=(action 'enableEventListeners')
+  scheduleUpdate=(action 'scheduleUpdate')
+  target=_popperTarget
+  update=(action 'update')
 )}}

--- a/addon/templates/components/ember-popper.hbs
+++ b/addon/templates/components/ember-popper.hbs
@@ -3,9 +3,10 @@
 {{#if renderInPlace}}
   <div id={{id}} class={{class}}>
     {{yield (hash
-      scheduleUpdate=(action 'scheduleUpdate')
-      enableEventListeners=(action 'enableEventListeners')
       disableEventListeners=(action 'disableEventListeners')
+      enableEventListeners=(action 'enableEventListeners')
+      scheduleUpdate=(action 'scheduleUpdate')
+      target=_popperTarget
     )}}
   </div>
 {{else}}
@@ -19,10 +20,11 @@
     {{!-- Add a wrapper around the yielded block so we have something for the Popper to target --}}
     <div id={{id}} class={{class}}>
       {{yield (hash
-        update=(action 'update')
-        scheduleUpdate=(action 'scheduleUpdate')
-        enableEventListeners=(action 'enableEventListeners')
         disableEventListeners=(action 'disableEventListeners')
+        enableEventListeners=(action 'enableEventListeners')
+        scheduleUpdate=(action 'scheduleUpdate')
+        target=_popperTarget
+        update=(action 'update')
       )}}
     </div>
   {{/-in-element}}

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 
 const Funnel = require('broccoli-funnel');
 const StripClassCallCheck = require('babel6-plugin-strip-class-callcheck');
-const fastbootTransform = require('fastboot-transform');
 const VersionChecker = require('ember-cli-version-checker');
+const fastbootTransform = require('fastboot-transform');
 
 module.exports = {
   name: 'ember-popper',


### PR DESCRIPTION
I'm in the process of making ember-attacher tagless, and I'd have to duplicate a lot of ember-popper's behavior to calculate the target. Seems better to just take advantage of the work ember-popper has already done.