### PR TITLE
Check for destroyed component

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -170,6 +170,10 @@ export default class EmberPopperBase extends Component {
   // ================== PRIVATE IMPLEMENTATION DETAILS ==================
 
   _updatePopper() {
+    if (this.isDestroyed) {
+      return;
+    }
+
     const popperTarget = this._getPopperTarget();
     const renderInPlace = this.get('_renderInPlace');
     const eventsEnabled = this.get('eventsEnabled');

--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -170,7 +170,7 @@ export default class EmberPopperBase extends Component {
   // ================== PRIVATE IMPLEMENTATION DETAILS ==================
 
   _updatePopper() {
-    if (this.isDestroyed) {
+    if (this.isDestroying || this.isDestroyed) {
       return;
     }
 


### PR DESCRIPTION
I think at this [line](https://github.com/kybishop/ember-popper/blob/master/addon/components/ember-popper-base.js#L129) there was a chance that `update` was called on an already destroyed component. This would cause `this._getPopperElement()` to return nothing (as the elements ID is not in DOM anymore), leading to an exception in popper.js. Have seens this at least in tests.