### PR TITLE
Fix version detection for Ember beta and alpha (canary)

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,14 +62,14 @@ module.exports = {
   treeForAddonTemplates(tree) {
     const { _emberChecker } = this;
 
-    if (_emberChecker.satisfies('>= 2.10.0')) {
+    if (_emberChecker.gte('2.10.0')) {
       tree = new Funnel(tree, {
         exclude: [
           'components/-ember-popper-legacy.hbs',
           'components/-ember-popper-legacy-1.11.hbs'
         ]
       });
-    } else if (_emberChecker.satisfies('>= 1.13.0')) {
+    } else if (_emberChecker.gte('1.13.0')) {
       tree = new Funnel(tree, {
         exclude: [
           'components/ember-popper.hbs',
@@ -93,7 +93,7 @@ module.exports = {
   treeForAddon(tree) {
     const { _emberChecker } = this;
 
-    if (_emberChecker.satisfies('>= 2.10.0')) {
+    if (_emberChecker.gte('2.10.0')) {
       tree = new Funnel(tree, {
         exclude: [
           'components/-ember-popper-legacy.js'


### PR DESCRIPTION
Oh man, this one took me so many hours (not to blame anyone here)... I was seeing test failures related to ember-popper (GlimmerVM exceptions, see https://travis-ci.org/kaliber5/ember-bootstrap/builds/273691334) in ember-try scenarios for Ember beta and canary versions. First suspected some Glimmer regression for some `-in-element` edge cases, until I finally realized that the build with ember beta was including the "legacy" ember-popper component!

This is because the `satisfies` method does not work like we need here for prerelease versions (see https://github.com/npm/node-semver#prerelease-tags): `semver.satisfies('2.15.0-beta.1', '> 2.10')` is `false`. `gte` does what we need here...