### PR TITLE
Fix node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "4"
 
 sudo: false
 dist: trusty

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-1.11',

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = {
   },
 
   treeForAddonTemplates(tree) {
-    const { _emberChecker } = this;
+    const _emberChecker = this._emberChecker;
 
     if (_emberChecker.gte('2.10.0')) {
       tree = new Funnel(tree, {
@@ -91,7 +91,7 @@ module.exports = {
   },
 
   treeForAddon(tree) {
-    const { _emberChecker } = this;
+    const _emberChecker = this._emberChecker;
 
     if (_emberChecker.gte('2.10.0')) {
       tree = new Funnel(tree, {


### PR DESCRIPTION
Destructuring is not supported. Also changed Travis to run with node 4, as is recommended by the default ember-cli addon blueprint.