### PR TITLE
fix(sourcemaps) include sourcemaps in assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
             return fastbootTransform(input);
           }
         },
-        vendor: ['popper.js.map']
+        public: ['popper.js.map']
       }
     }
   },


### PR DESCRIPTION
Fixes #46 

Huge thanks for the repro @urbany!

I have confirmed that this does not impact the size of production builds (i.e. the sourcemaps are still stripped).