### PR TITLE
bugfix(fastboot): Adds element polyfill

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -7,6 +7,8 @@ import { tagName } from 'ember-decorators/component';
 import { argument, type } from 'ember-argument-decorators';
 import { unionOf } from 'ember-argument-decorators/types';
 
+import { Element } from '../utils/globals';
+
 import layout from '../templates/components/ember-popper';
 
 @tagName('')

--- a/addon/utils/globals.js
+++ b/addon/utils/globals.js
@@ -1,0 +1,5 @@
+/**
+ * Definitions of types polyfills for fastboot
+ */
+
+export const Element = window ? window.Element : class Element {};


### PR DESCRIPTION
Fixes fastboot by adding a polyfill for the `Element` class if it does not exist. I don't think this is necessarily a good general solution, but for our purposes I think it should be fine, in general users shouldn't be able to get any elements manually to pass into a popover in Fastboot, and we don't run our code to manually set it either.

Still looking into a generic solution here, will report back on it 