### PR TITLE
refactor(raf): Remove requestAnimationFrame

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -145,9 +145,7 @@ export default class EmberPopperBase extends Component {
   // ================== LIFECYCLE HOOKS ==================
 
   didUpdateAttrs() {
-    this._updateRAF = requestAnimationFrame(() => {
-      this._updatePopper();
-    });
+    this._updatePopper();
   }
 
   didInsertElement() {
@@ -249,7 +247,7 @@ export default class EmberPopperBase extends Component {
 
       // Execute the onFoundTarget hook last to ensure the Popper is initialized on the target
       if (isPopperTargetDifferent && this.get('onFoundTarget')) {
-        this.get('onFoundTarget')(popperTarget);
+        this.sendAction('onFoundTarget', popperTarget);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-cli-version-checker": "^2.1.0",
     "ember-decorators": "^1.3.1",
     "ember-legacy-class-transform": "~0.1.2",
+    "ember-raf-scheduler": "^0.1.0",
     "fastboot-transform": "^0.1.0",
     "popper.js": "^1.12.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,6 +2555,12 @@ ember-qunit@^2.2.0:
   dependencies:
     ember-test-helpers "^0.6.3"
 
+ember-raf-scheduler@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-raf-scheduler/-/ember-raf-scheduler-0.1.0.tgz#a22a02d238c374499231c03ab9c5b9887c72a853"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-resolver@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ember-resolver/-/ember-resolver-4.5.0.tgz#9248bf534dfc197fafe3118fff538d436078bf99"


### PR DESCRIPTION
This PR began with an attempt to replace RAF with the new ember-raf-scheduler, but after testing I realized that our usage of RAF doesn't appear to actually have any performance benefits. With that in mind, it definitely makes more sense to not complicate the runloop and remove it entirely for now.

With RAF:

<img width="993" alt="screen shot 2017-10-28 at 9 41 46 am" src="https://user-images.githubusercontent.com/685518/32136570-e60bc99e-bbc4-11e7-9fc0-2384dd9ae674.png">

<img width="993" alt="screen shot 2017-10-28 at 9 41 52 am" src="https://user-images.githubusercontent.com/685518/32136572-e9d85984-bbc4-11e7-9056-16469150be48.png">

Without RAF:

<img width="991" alt="screen shot 2017-10-28 at 9 41 01 am" src="https://user-images.githubusercontent.com/685518/32136573-f4277384-bbc4-11e7-8c4a-f09495dbf604.png">

Both actions in total take 3ms. I think what's going on here is creating a new Popper will modify the DOM in some way before it measures, which forces it to do a layout anyways.

Note: Popper's `scheduleUpdate` function is still going to be using RAF and it will likely be more performant than a normal update. We should consider replacing it with an ember-raf-scheduler based one to make sure it integrates with tests/Ember correctly.

```js
@action
scheduleUpdate() {
  raf.schedule('affect', this._popper.update);
}
```