### PR TITLE
bugfix(legacy): Bumps ember-legacy-class-transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-version-checker": "^2.1.0",
     "ember-compatibility-helpers": "^0.1.2",
     "ember-decorators": "^1.3.1",
-    "ember-legacy-class-transform": "~0.1.2",
+    "ember-legacy-class-transform": "^0.1.3",
     "ember-raf-scheduler": "^0.1.0",
     "fastboot-transform": "^0.1.0",
     "popper.js": "^1.12.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,9 +2513,9 @@ ember-hash-helper-polyfill@^0.1.2:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-legacy-class-transform@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.2.tgz#f09e1b002ac4141096051a4ce387ba6828eddb16"
+ember-legacy-class-transform@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.3.tgz#af943fd46aa050981b7f0927bf70ef8736878682"
   dependencies:
     babel-plugin-ember-legacy-class-constructor "^0.1.4"
     ember-cli-babel "^6.3.0"


### PR DESCRIPTION
NPM appears to be treating pre-1.0 packages as if minor versions were major versions and patch versions were minor versions. This prevented me from getting a bugfix for the ember-legacy-class-transform dependency in, thus the PR