### PR TITLE
update(argument): Updates @argument and types

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -3,15 +3,17 @@ import { assert } from '@ember/debug';
 import Component from '@ember/component';
 
 import { action, computed } from 'ember-decorators/object';
-import { argument } from '@ember-decorators/argument';
-import { type, unionOf } from '@ember-decorators/argument/type';
 import { tagName } from 'ember-decorators/component';
+
+import { argument } from '@ember-decorators/argument';
+import { type, unionOf, optional } from '@ember-decorators/argument/type';
+import { Action, Element } from '@ember-decorators/argument/types';
 
 import { scheduler as raf } from 'ember-raf-scheduler';
 
-import { Element } from '../utils/globals';
-
 import layout from '../templates/components/ember-popper';
+
+const Selector = unionOf('string', Element);
 
 @tagName('')
 export default class EmberPopperBase extends Component {
@@ -22,7 +24,7 @@ export default class EmberPopperBase extends Component {
   /**
    * Whether event listeners, resize and scroll, for repositioning the popper are initially enabled.
    */
-  @argument
+  @argument({ defaultIfUndefined: true })
   @type('boolean')
   eventsEnabled = true
 
@@ -31,7 +33,7 @@ export default class EmberPopperBase extends Component {
    * https://popper.js.org/popper-documentation.html#Popper.DEFAULTS
    */
   @argument
-  @type(unionOf(null, 'object'))
+  @type(optional('object'))
   modifiers = null
 
   /**
@@ -39,7 +41,7 @@ export default class EmberPopperBase extends Component {
    * The target is passed in as an argument to the function.
    */
   @argument
-  @type(unionOf(null, 'action'))
+  @type(optional(Action))
   registerAPI = null
 
   /**
@@ -47,7 +49,7 @@ export default class EmberPopperBase extends Component {
    * https://popper.js.org/popper-documentation.html#Popper.Defaults.onCreate
    */
   @argument
-  @type(unionOf(null, 'function'))
+  @type(optional(Function))
   onCreate = null
 
   /**
@@ -55,13 +57,13 @@ export default class EmberPopperBase extends Component {
    * https://popper.js.org/popper-documentation.html#Popper.Defaults.onUpdate
    */
   @argument
-  @type(unionOf(null, 'function'))
+  @type(optional(Function))
   onUpdate = null
 
   /**
    * Placement of the popper. One of ['top', 'right', 'bottom', 'left'].
    */
-  @argument
+  @argument({ defaultIfUndefined: true })
   @type('string')
   placement = 'bottom'
 
@@ -70,15 +72,15 @@ export default class EmberPopperBase extends Component {
    * See the block-comment in the template for more details. `.ember-application` is applied
    * to the root element of the ember app by default, so we move it up to there.
    */
-  @argument
-  @type(unionOf('string', Element))
+  @argument({ defaultIfUndefined: true })
+  @type(Selector)
   popperContainer = '.ember-application'
 
   /**
    * The element the popper will target. If left blank, will be set to the ember-popper's parent.
    */
   @argument
-  @type(unionOf(null, 'string', Element))
+  @type(optional(Selector))
   popperTarget = null
 
   /**
@@ -86,7 +88,7 @@ export default class EmberPopperBase extends Component {
    * z-index issues where your popper will be overlapped by DOM elements that aren't nested as
    * deeply in the DOM tree.
    */
-  @argument
+  @argument({ defaultIfUndefined: true })
   @type('boolean')
   renderInPlace = false
 

--- a/addon/utils/globals.js
+++ b/addon/utils/globals.js
@@ -1,5 +1,0 @@
-/**
- * Definitions of types polyfills for fastboot
- */
-
-export const Element = window ? window.Element : class Element {};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/argument": "~0.7.1",
+    "@ember-decorators/argument": "^0.8.2",
     "babel-eslint": "^8.0.1",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-funnel": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,11 @@
 # yarn lockfile v1
 
 
-"@ember-decorators/argument@~0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.7.1.tgz#333f112159a242c332ca4d2495caff975d6d964a"
+"@ember-decorators/argument@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.2.tgz#f6dcd92c5c507356c3fc118e159e9ae64f4af79b"
   dependencies:
-    babel-plugin-filter-imports "^1.1.0"
+    babel-plugin-filter-imports "^1.1.1"
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^6.3.0"
     ember-cli-version-checker "^2.0.0"
@@ -581,9 +581,9 @@ babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
 
-babel-plugin-filter-imports@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.1.0.tgz#e5ea78f58f7fed4a22e59e136b52994c5fda7bad"
+babel-plugin-filter-imports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.1.1.tgz#0f418fb517a7c64b54461b947940081e51b3fd9d"
   dependencies:
     babel-types "^6.26.0"
     lodash "^4.17.4"


### PR DESCRIPTION
Updates `@ember-decorators/argument` and uses the new `optional` helper and predefined types. Also flips on `defaultIfUndefined` for all non-optional arguments, which should allow people to proxy values through if they want to (per [this comment](https://github.com/kybishop/ember-popper/pull/51#issuecomment-342284004))

This shouldn't change existing behavior or be more restrictive, I believe it will be less restrictive overall, so a patch (minor) version bump is probably fine here.