### PR TITLE
bugfix(target): Changes the target property to avoid collisions - BREAKING

### DIFF
--- a/addon/components/-ember-popper-legacy.js
+++ b/addon/components/-ember-popper-legacy.js
@@ -24,7 +24,7 @@ export default class EmberPopper extends EmberPopperBase {
       addObserver(this, 'onUpdate', this, this._updatePopper);
       addObserver(this, 'placement', this, this._updatePopper);
       addObserver(this, 'popperContainer', this, this._updatePopper);
-      addObserver(this, 'target', this, this._updatePopper);
+      addObserver(this, 'popperTarget', this, this._updatePopper);
 
       super.didRender(...arguments);
     }
@@ -42,7 +42,7 @@ export default class EmberPopper extends EmberPopperBase {
       removeObserver(this, 'onUpdate', this, this._updatePopper);
       removeObserver(this, 'placement', this, this._updatePopper);
       removeObserver(this, 'popperContainer', this, this._updatePopper);
-      removeObserver(this, 'target', this, this._updatePopper);
+      removeObserver(this, 'popperTarget', this, this._updatePopper);
     }
 
     const element = this._getPopperElement();

--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -66,15 +66,6 @@ export default class EmberPopperBase extends Component {
   placement = 'bottom'
 
   /**
-   * The popper element needs to be moved higher in the DOM tree to avoid z-index issues.
-   * See the block-comment in the template for more details. `.ember-application` is applied
-   * to the root element of the ember app by default, so we move it up to there.
-   */
-  @argument
-  @type(unionOf('string', Element))
-  popperContainer = '.ember-application'
-
-  /**
    * If `true`, the popper element will not be moved to popperContainer. WARNING: This can cause
    * z-index issues where your popper will be overlapped by DOM elements that aren't nested as
    * deeply in the DOM tree.
@@ -84,11 +75,20 @@ export default class EmberPopperBase extends Component {
   renderInPlace = false
 
   /**
+   * The popper element needs to be moved higher in the DOM tree to avoid z-index issues.
+   * See the block-comment in the template for more details. `.ember-application` is applied
+   * to the root element of the ember app by default, so we move it up to there.
+   */
+  @argument
+  @type(unionOf('string', Element))
+  popperContainer = '.ember-application'
+
+  /**
    * The element the popper will target. If left blank, will be set to the ember-popper's parent.
    */
   @argument
   @type(unionOf(null, 'string', Element))
-  target = null
+  popperTarget = null
 
   // ================== PRIVATE PROPERTIES ==================
 
@@ -269,19 +269,19 @@ export default class EmberPopperBase extends Component {
    * Used to get the popper target whenever updating the Popper
    */
   _getPopperTarget() {
-    const target = this.get('target');
+    const targetSelector = this.get('popperTarget');
 
     let popperTarget;
 
     // If there is no target, set the target to the parent element
-    if (!target) {
+    if (!targetSelector) {
       popperTarget = this._initialParentNode;
-    } else if (target instanceof Element) {
-      popperTarget = target;
+    } else if (targetSelector instanceof Element) {
+      popperTarget = targetSelector;
     } else {
-      const nodes = document.querySelectorAll(target);
+      const nodes = document.querySelectorAll(targetSelector);
 
-      assert(`ember-popper with target selector "${target}" found ${nodes.length}`
+      assert(`ember-popper with target selector "${targetSelector}" found ${nodes.length}`
              + 'possible targets when there should be exactly 1', nodes.length === 1);
 
       popperTarget = nodes[0];

--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -66,15 +66,6 @@ export default class EmberPopperBase extends Component {
   placement = 'bottom'
 
   /**
-   * If `true`, the popper element will not be moved to popperContainer. WARNING: This can cause
-   * z-index issues where your popper will be overlapped by DOM elements that aren't nested as
-   * deeply in the DOM tree.
-   */
-  @argument
-  @type('boolean')
-  renderInPlace = false
-
-  /**
    * The popper element needs to be moved higher in the DOM tree to avoid z-index issues.
    * See the block-comment in the template for more details. `.ember-application` is applied
    * to the root element of the ember app by default, so we move it up to there.
@@ -89,6 +80,15 @@ export default class EmberPopperBase extends Component {
   @argument
   @type(unionOf(null, 'string', Element))
   popperTarget = null
+
+  /**
+   * If `true`, the popper element will not be moved to popperContainer. WARNING: This can cause
+   * z-index issues where your popper will be overlapped by DOM elements that aren't nested as
+   * deeply in the DOM tree.
+   */
+  @argument
+  @type('boolean')
+  renderInPlace = false
 
   // ================== PRIVATE PROPERTIES ==================
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -18,7 +18,7 @@
 </div>
 
 {{#if showTargetedPopper}}
-  {{#ember-popper class="popper" target=".right"}}
+  {{#ember-popper class="popper" popperTarget=".right"}}
     Hello from the right!
     <br>
     I explicitly target the right div

--- a/tests/integration/components/ember-popper/register-api-test.js
+++ b/tests/integration/components/ember-popper/register-api-test.js
@@ -10,7 +10,7 @@ moduleForComponent('ember-popper', 'Integration | Component | registerAPI', {
   }
 });
 
-test('undefined target: registerAPI returns the popper element', function(assert) {
+test('undefined popperTarget: registerAPI returns the popper element', function(assert) {
   this.on('registerAPI', ({ popperElement }) => {
     const parent = document.querySelector('.popper-element');
     assert.equal(popperElement, parent);
@@ -25,7 +25,7 @@ test('undefined target: registerAPI returns the popper element', function(assert
   `);
 });
 
-test('undefined target: registerAPI returns the parent', function(assert) {
+test('undefined popperTarget: registerAPI returns the parent', function(assert) {
   this.on('registerAPI', ({ popperTarget }) => {
     const parent = document.querySelector('.parent');
     assert.equal(popperTarget, parent);
@@ -40,7 +40,7 @@ test('undefined target: registerAPI returns the parent', function(assert) {
   `);
 });
 
-test('explicit target: registerAPI returns the explicit target', function(assert) {
+test('explicit popperTarget: registerAPI returns the explicit target', function(assert) {
   this.on('registerAPI', ({ popperTarget }) => {
     const parent = document.querySelector('.parent');
     assert.equal(popperTarget, parent);
@@ -52,7 +52,7 @@ test('explicit target: registerAPI returns the explicit target', function(assert
 
     {{#ember-popper class='popper-element'
                     registerAPI='registerAPI'
-                    target='.parent'}}
+                    popperTarget='.parent'}}
       template block text
     {{/ember-popper}}
   `);
@@ -92,7 +92,7 @@ test('when the popper target changes the API reregisters with the new target', f
     <div class='newTarget'>
     </div>
 
-    {{#ember-popper class='popper-element' registerAPI='registerAPI' target=target}}
+    {{#ember-popper class='popper-element' registerAPI='registerAPI' popperTarget=target}}
       template block text
     {{/ember-popper}}
   `);

--- a/tests/integration/components/ember-popper/target-test.js
+++ b/tests/integration/components/ember-popper/target-test.js
@@ -6,7 +6,7 @@ moduleForComponent('ember-popper', 'Integration | Component | target', {
   integration: true
 });
 
-test('undefined target: it targets the parent', function(assert) {
+test('undefined popperTarget: it targets the parent', function(assert) {
   this.render(hbs`
     <div class='parent' style='height: 50px; width: 100%;'>
       {{#ember-popper class='popper-element' placement='bottom'}}
@@ -25,12 +25,12 @@ test('undefined target: it targets the parent', function(assert) {
   });
 });
 
-test('explicit target: it targets the explicit target', function(assert) {
+test('explicit popperTarget: it targets the explicit target', function(assert) {
   this.render(hbs`
     <div class='parent' style='height: 50px; width: 100%;'>
     </div>
 
-    {{#ember-popper class='popper-element' placement='top' target='.parent'}}
+    {{#ember-popper class='popper-element' placement='top' popperTarget='.parent'}}
       template block text
     {{/ember-popper}}
   `);


### PR DESCRIPTION
The target property is used internally in Ember to determine where to send actions.
Recent changes have started causing failures since we define a target property on
the components. This may be a regression, but we should also change the property
name to avoid any possible collisions.