### PR TITLE
feat(basic hide/show functionality)

### DIFF
--- a/addon/components/-ember-popper-legacy.js
+++ b/addon/components/-ember-popper-legacy.js
@@ -1,19 +1,24 @@
 import { addObserver, removeObserver } from '@ember/object/observers';
+import { guidFor } from '@ember/object/internals';
 
 import EmberPopperBase from './ember-popper-base';
 import { computed } from 'ember-decorators/object';
 
-import { tagName } from 'ember-decorators/component';
-
 import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
 
-@tagName('div')
 export default class EmberPopper extends EmberPopperBase {
 
   // ================== LIFECYCLE HOOKS ==================
 
+  init() {
+    this.id = this.id || `${guidFor(this)}-popper`;
+    this._parentFinder = self.document ? self.document.createTextNode('') : '';
+
+    super.init(...arguments);
+  }
+
   didInsertElement() {
-    this._initialParentNode = this.element.parentNode;
+    this._initialParentNode = this._parentFinder.parentNode;
 
     if (!GTE_EMBER_1_13) {
       addObserver(this, 'eventsEnabled', this, this._updatePopper);
@@ -47,7 +52,7 @@ export default class EmberPopper extends EmberPopperBase {
 
     const element = this._getPopperElement();
 
-    if (element.parentNode !== this._initialParentNode) {
+    if (element && element.parentNode !== this._initialParentNode) {
       element.parentNode.removeChild(element);
     }
   }
@@ -61,15 +66,11 @@ export default class EmberPopper extends EmberPopperBase {
 
     // If renderInPlace is false, move the element to the popperContainer to avoid z-index issues.
     // See renderInPlace for more details.
-    if (renderInPlace === false && element.parentNode !== popperContainer) {
+    if (renderInPlace === false && element && element.parentNode !== popperContainer) {
       popperContainer.appendChild(element);
     }
 
     super._updatePopper();
-  }
-
-  _getPopperElement() {
-    return this.element;
   }
 
   @computed()

--- a/addon/templates/components/-ember-popper-legacy-1.11.hbs
+++ b/addon/templates/components/-ember-popper-legacy-1.11.hbs
@@ -1,1 +1,3 @@
-{{yield _popperHash}}
+{{#if shouldRender}}
+  {{yield _popperHash}}
+{{/if}}

--- a/addon/templates/components/-ember-popper-legacy.hbs
+++ b/addon/templates/components/-ember-popper-legacy.hbs
@@ -1,6 +1,12 @@
-{{yield (hash
-  disableEventListeners=(action 'disableEventListeners')
-  enableEventListeners=(action 'enableEventListeners')
-  scheduleUpdate=(action 'scheduleUpdate')
-  update=(action 'update')
-)}}
+{{unbound _parentFinder}}
+
+{{#if shouldRender}}
+  <div id={{id}} class={{class}} role={{ariaRole}}>
+    {{yield (hash
+      disableEventListeners=(action 'disableEventListeners')
+      enableEventListeners=(action 'enableEventListeners')
+      scheduleUpdate=(action 'scheduleUpdate')
+      update=(action 'update')
+    )}}
+  </div>
+{{/if}}

--- a/addon/templates/components/ember-popper.hbs
+++ b/addon/templates/components/ember-popper.hbs
@@ -1,23 +1,7 @@
 {{unbound _parentFinder}}
 
-{{#if renderInPlace}}
-  <div id={{id}} class={{class}} role={{ariaRole}}>
-    {{yield (hash
-      disableEventListeners=(action 'disableEventListeners')
-      enableEventListeners=(action 'enableEventListeners')
-      scheduleUpdate=(action 'scheduleUpdate')
-      update=(action 'update')
-    )}}
-  </div>
-{{else}}
-  {{!-- Elements that exist deep within the document tree are given an implicitly lower z-index
-        value than elements that aren't as deep in the tree; this has the effect of hiding our
-        ember-popper behind less-nested elements. Due to the way z-indexing works, we cannot simply
-        add a higher z-index value to our ember-popper. To avoid this issue, we render the element
-        on the document body, giving it the highest default z-index value. --}}
-
-  {{#-in-element _popperContainer}}
-    {{!-- Add a wrapper around the yielded block so we have something for the Popper to target --}}
+{{#if shouldRender}}
+  {{#if renderInPlace}}
     <div id={{id}} class={{class}} role={{ariaRole}}>
       {{yield (hash
         disableEventListeners=(action 'disableEventListeners')
@@ -26,5 +10,23 @@
         update=(action 'update')
       )}}
     </div>
-  {{/-in-element}}
+  {{else}}
+    {{!-- Elements that exist deep within the document tree are given an implicitly lower z-index
+          value than elements that aren't as deep in the tree; this has the effect of hiding our
+          ember-popper behind less-nested elements. Due to the way z-indexing works, we cannot simply
+          add a higher z-index value to our ember-popper. To avoid this issue, we render the element
+          on the document body, giving it the highest default z-index value. --}}
+
+    {{#-in-element _popperContainer}}
+      {{!-- Add a wrapper around the yielded block so we have something for the Popper to target --}}
+      <div id={{id}} class={{class}} role={{ariaRole}}>
+        {{yield (hash
+          disableEventListeners=(action 'disableEventListeners')
+          enableEventListeners=(action 'enableEventListeners')
+          scheduleUpdate=(action 'scheduleUpdate')
+          update=(action 'update')
+        )}}
+      </div>
+    {{/-in-element}}
+  {{/if}}
 {{/if}}

--- a/tests/integration/components/ember-popper/register-api-test.js
+++ b/tests/integration/components/ember-popper/register-api-test.js
@@ -109,3 +109,36 @@ test('when the popper target changes the API reregisters with the new target', f
     assert.equal(foundTarget, newTarget, 'the target changed');
   });
 });
+
+test('when shouldRender changes the API reregisters with the newly created popper element', function(assert) {
+  let callCount = 0;
+  let foundPopperElement;
+
+  this.on('registerAPI', ({ popperElement }) => {
+    callCount += 1;
+    foundPopperElement = popperElement;
+  });
+  this.set('shouldRender', false);
+
+  this.render(hbs`
+    {{#ember-popper id='popper' registerAPI='registerAPI' shouldRender=shouldRender}}
+      template block text
+    {{/ember-popper}}
+  `);
+
+  assert.equal(callCount, 1, 'registerApi called an unexpected number of times');
+  assert.equal(foundPopperElement, null);
+
+  this.set('shouldRender', true);
+
+  return wait().then(() => {
+    assert.equal(callCount, 2, 'registerApi should have been called twice');
+
+    const popperElement = document.getElementById('popper');
+
+    // Sanity check
+    assert.ok(popperElement);
+
+    assert.equal(foundPopperElement, popperElement);
+  });
+});

--- a/tests/integration/components/ember-popper/should-render-test.js
+++ b/tests/integration/components/ember-popper/should-render-test.js
@@ -1,0 +1,55 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('ember-popper', 'Integration | Component | shouldRender', {
+  integration: true
+});
+
+test('false: doesn\'t render the popper element', function(assert) {
+  this.render(hbs`
+    <div>
+      {{#ember-popper class='popper' shouldRender=false}}
+        template block text
+      {{/ember-popper}}
+    </div>
+  `);
+
+  const popper = document.querySelector('.hello');
+
+  assert.equal(popper, null);
+});
+
+test('true: renders the popper element', function(assert) {
+  this.render(hbs`
+  <div>
+    {{#ember-popper class='popper' shouldRender=true}}
+      template block text
+    {{/ember-popper}}
+  </div>
+  `);
+
+  const popper = document.querySelector('.popper');
+
+  assert.equal(popper.innerHTML.trim(), 'template block text');
+});
+
+test('toggling: correctly adds a popper instance to the popper element', function(assert) {
+  this.set('shouldRender', false);
+
+  this.render(hbs`
+    <div>
+      {{#ember-popper class='popper' shouldRender=shouldRender}}
+        template block text
+      {{/ember-popper}}
+    </div>
+  `);
+
+  assert.equal(document.querySelector('.popper'), null, 'popper is not rendered');
+
+  this.set('shouldRender', true);
+
+  const popper = document.querySelector('.popper');
+
+  assert.equal(popper.innerHTML.trim(), 'template block text');
+  assert.ok(popper.hasAttribute('x-placement'));
+});


### PR DESCRIPTION
Ember-popper has two major features:
1. Provide a parent element programmatically
2. Position an element via Popper.js

This PR seeks to leverage our ability to find a parent element while deferring positioning until the consumer is ready.

This enables two new major use-cases:
1. Consumers can potentially use this hide/show logic to power super basic (read: performant) tooltip components
2. Tooltip libraries can implement lazy rendering, greatly improving their performance.

Lazy rendering currently exists in ember-attacher, but it is only pseudo-lazy since we still need the target from ember-popper, which currently means rendering the whole popper element.

EDIT: I'll keep this around for a while before merging so people can share thoughts. This has been tested successfully in a spike of true lazy rendering with ember-attacher.