### PR TITLE
[BREAKING] ember-popper component now requires a target. new component, ember-popper-targeting-parent for those that need it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ npm-debug.log*
 yarn-error.log
 testem.log
 .tern-project
+.DS_Store
 
 # ember-try
 .node_modules.ember-try/

--- a/addon/components/-ember-popper-targeting-parent-legacy.js
+++ b/addon/components/-ember-popper-targeting-parent-legacy.js
@@ -7,14 +7,10 @@ import { tagName } from 'ember-decorators/component';
 import { type } from '@ember-decorators/argument/type';
 
 @tagName('div')
-export default class EmberPopper extends EmberPopperBase {
-
-  /**
-   * The element the popper will target.
-   */
+export default class EmberPopperTargetingParent extends EmberPopperBase {
   @argument
-  @type(Element)
-  popperTarget = null
+  @type(undefined)
+  popperTarget = undefined
 
   // ================== LIFECYCLE HOOKS ==================
 
@@ -86,5 +82,9 @@ export default class EmberPopper extends EmberPopperBase {
       scheduleUpdate: this.scheduleUpdate.bind(this),
       update: this.update.bind(this)
     };
+  }
+
+  _getPopperTarget() {
+    return this._initialParentNode;
   }
 }

--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -1,17 +1,12 @@
-import { assert } from '@ember/debug';
-
 import Component from '@ember/component';
-
-import { action, computed } from 'ember-decorators/object';
-import { tagName } from 'ember-decorators/component';
-
-import { argument } from '@ember-decorators/argument';
-import { type, unionOf, optional } from '@ember-decorators/argument/type';
-import { Action, Element } from '@ember-decorators/argument/types';
-
-import { scheduler as raf } from 'ember-raf-scheduler';
-
 import layout from '../templates/components/ember-popper';
+import { Action, Element } from '@ember-decorators/argument/types';
+import { action, computed } from 'ember-decorators/object';
+import { argument } from '@ember-decorators/argument';
+import { assert } from '@ember/debug';
+import { scheduler as raf } from 'ember-raf-scheduler';
+import { tagName } from 'ember-decorators/component';
+import { type, unionOf, optional } from '@ember-decorators/argument/type';
 
 const Selector = unionOf('string', Element);
 
@@ -67,13 +62,6 @@ export default class EmberPopperBase extends Component {
   @argument({ defaultIfUndefined: true })
   @type(Selector)
   popperContainer = '.ember-application'
-
-  /**
-   * The element the popper will target. If left blank, will be set to the ember-popper's parent.
-   */
-  @argument
-  @type(optional(Selector))
-  popperTarget = null
 
   /**
    * An optional function to be called when a new target is located.
@@ -267,29 +255,8 @@ export default class EmberPopperBase extends Component {
     return self.document.getElementById(this.id);
   }
 
-  /**
-   * Used to get the popper target whenever updating the Popper
-   */
   _getPopperTarget() {
-    const targetSelector = this.get('popperTarget');
-
-    let popperTarget;
-
-    // If there is no target, set the target to the parent element
-    if (!targetSelector) {
-      popperTarget = this._initialParentNode;
-    } else if (targetSelector instanceof Element) {
-      popperTarget = targetSelector;
-    } else {
-      const nodes = document.querySelectorAll(targetSelector);
-
-      assert(`ember-popper with target selector "${targetSelector}" found ${nodes.length}`
-             + 'possible targets when there should be exactly 1', nodes.length === 1);
-
-      popperTarget = nodes[0];
-    }
-
-    return popperTarget;
+    return this.get('popperTarget');
   }
 
   _getPublicAPI() {

--- a/addon/components/ember-popper-targeting-parent.js
+++ b/addon/components/ember-popper-targeting-parent.js
@@ -1,0 +1,29 @@
+import EmberPopperBase from './ember-popper-base';
+import layout from '../templates/components/ember-popper-targeting-parent';
+import { guidFor } from '@ember/object/internals';
+
+export default class EmberPopperTargetingParent extends EmberPopperBase {
+  layout = layout
+
+  // ================== LIFECYCLE HOOKS ==================
+
+  init() {
+    this.id = this.id || `${guidFor(this)}-popper`;
+    this._parentFinder = self.document ? self.document.createTextNode('') : '';
+
+    super.init(...arguments);
+  }
+
+  didInsertElement() {
+    this._initialParentNode = this._parentFinder.parentNode;
+
+    super.didInsertElement(...arguments);
+  }
+
+  /**
+   * Used to get the popper target whenever updating the Popper
+   */
+  _getPopperTarget() {
+    return this._initialParentNode;
+  }
+}

--- a/addon/components/ember-popper.js
+++ b/addon/components/ember-popper.js
@@ -1,20 +1,22 @@
 import EmberPopperBase from './ember-popper-base';
+import { Element } from '@ember-decorators/argument/types';
+import { argument } from '@ember-decorators/argument';
 import { guidFor } from '@ember/object/internals';
+import { type } from '@ember-decorators/argument/type';
 
 export default class EmberPopper extends EmberPopperBase {
+  /**
+   * The element the popper will target.
+   */
+  @argument
+  @type(Element)
+  popperTarget = null
 
   // ================== LIFECYCLE HOOKS ==================
 
   init() {
     this.id = this.id || `${guidFor(this)}-popper`;
-    this._parentFinder = self.document ? self.document.createTextNode('') : '';
 
     super.init(...arguments);
-  }
-
-  didInsertElement() {
-    this._initialParentNode = this._parentFinder.parentNode;
-
-    super.didInsertElement(...arguments);
   }
 }

--- a/addon/templates/components/ember-popper-targeting-parent.hbs
+++ b/addon/templates/components/ember-popper-targeting-parent.hbs
@@ -1,3 +1,5 @@
+{{unbound _parentFinder}}
+
 {{#if renderInPlace}}
   <div id={{id}} class={{class}} role={{ariaRole}}>
     {{yield (hash

--- a/app/components/ember-popper-targeting-parent.js
+++ b/app/components/ember-popper-targeting-parent.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-popper/components/ember-popper-targeting-parent';

--- a/app/templates/components/ember-popper-targeting-parent.js
+++ b/app/templates/components/ember-popper-targeting-parent.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-popper/templates/components/ember-popper-targeting-parent';

--- a/index.js
+++ b/index.js
@@ -59,29 +59,54 @@ module.exports = {
     this._hasSetupBabelOptions = true;
   },
 
+  treeForAddon(tree) {
+    const _emberChecker = this._emberChecker;
+
+    if (_emberChecker.gte('2.10.0')) {
+      tree = new Funnel(tree, {
+        exclude: [
+          'components/-ember-popper-legacy.js',
+          'components/-ember-popper-targeting-parent-legacy.js'
+        ]
+      });
+    } else {
+      tree = new Funnel(tree, {
+        exclude: [
+          'components/ember-popper-targeting-parent.js',
+          'components/ember-popper.js'
+        ],
+        getDestinationPath: replaceLegacyPath
+      });
+    }
+
+    return this._super.treeForAddon.call(this, tree);
+  },
+
   treeForAddonTemplates(tree) {
     const _emberChecker = this._emberChecker;
 
     if (_emberChecker.gte('2.10.0')) {
       tree = new Funnel(tree, {
         exclude: [
-          'components/-ember-popper-legacy.hbs',
-          'components/-ember-popper-legacy-1.11.hbs'
+          'components/-ember-popper-legacy-1.11.hbs',
+          'components/-ember-popper-legacy.hbs'
         ]
       });
     } else if (_emberChecker.gte('1.13.0')) {
       tree = new Funnel(tree, {
         exclude: [
-          'components/ember-popper.hbs',
-          'components/-ember-popper-legacy-1.11.hbs'
+          'components/-ember-popper-legacy-1.11.hbs',
+          'components/ember-popper-targeting-parent.hbs',
+          'components/ember-popper.hbs'
         ],
         getDestinationPath: replaceLegacyPath
       });
     } else {
       tree = new Funnel(tree, {
         exclude: [
-          'components/ember-popper.hbs',
-          'components/-ember-popper-legacy.hbs'
+          'components/-ember-popper-legacy.hbs',
+          'components/ember-popper-targeting-parent.hbs',
+          'components/ember-popper.hbs'
         ],
         getDestinationPath: replaceLegacyPath
       });
@@ -90,28 +115,33 @@ module.exports = {
     return this._super.treeForAddonTemplates.call(this, tree);
   },
 
-  treeForAddon(tree) {
-    const _emberChecker = this._emberChecker;
-
-    if (_emberChecker.gte('2.10.0')) {
+  treeForApp(tree) {
+    if (this._emberChecker.lt('2.10.0')) {
       tree = new Funnel(tree, {
         exclude: [
-          'components/-ember-popper-legacy.js'
+          'templates/components/ember-popper-targeting-parent.js'
         ]
-      });
-    } else {
-      tree = new Funnel(tree, {
-        exclude: [
-          'components/ember-popper.js'
-        ],
-        getDestinationPath: replaceLegacyPath
       });
     }
 
-    return this._super.treeForAddon.call(this, tree);
+    return this._super.treeForApp.call(this, tree);
+  },
+
+  treeForTemplates(tree) {
+    if (this._emberChecker.lt('2.10.0')) {
+      tree = new Funnel(tree, {
+        exclude: [
+          'components/ember-popper-targeting-parent.js'
+        ]
+      });
+    }
+
+    return this._super.treeForTemplates.call(this, tree);
   }
 };
 
 function replaceLegacyPath(relativePath) {
-  return relativePath.replace(/-ember-popper-legacy(-1.11)?/g, 'ember-popper');
+  return relativePath
+    .replace(/-ember-popper-legacy(-1.11)?/g, 'ember-popper')
+    .replace(/-ember-popper-targeting-parent-legacy/g, 'ember-popper-targeting-parent');
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ember-hash-helper-polyfill": "^0.2.0",
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-event-dispatcher": "^0.6.3",
-    "ember-native-dom-helpers": "^0.5.8",
+    "ember-native-dom-helpers": "^0.5.10",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.17.0",
     "eslint-plugin-ember-suave": "^1.0.0",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,8 +1,13 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
   eventsEnabled: true,
   showTargetedPopper: true,
+
+  _popperTarget: computed(function() {
+    return document.querySelector('.right');
+  }),
 
   actions: {
     toggleShowTargetedPopper() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,24 +1,24 @@
 <div class="row">
   <div class="left">
-    {{#ember-popper id='parent' class='popper' eventsEnabled=eventsEnabled}}
+    {{#ember-popper-targeting-parent id='parent' class='popper' eventsEnabled=eventsEnabled}}
       Hello from the left! I have no explicit target.
       <div class="popper-arrow" x-arrow></div>
 
-      {{#ember-popper class="popper" renderInPlace=true}}
+      {{#ember-popper-targeting-parent class="popper" renderInPlace=true}}
         <span style="white-space: nowrap">P O P P E R C E P T I O N</span>
         <br>
         I also have no explicit target,
         <br>
         but am a child of the popper above
         <div class="popper-arrow" x-arrow></div>
-      {{/ember-popper}}
-    {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
+    {{/ember-popper-targeting-parent}}
   </div>
   <div class="right"></div>
 </div>
 
 {{#if showTargetedPopper}}
-  {{#ember-popper class="popper" popperTarget=".right"}}
+  {{#ember-popper class="popper" popperTarget=_popperTarget}}
     Hello from the right!
     <br>
     I explicitly target the right div

--- a/tests/integration/components/ember-popper-targeting-parent-test.js
+++ b/tests/integration/components/ember-popper-targeting-parent-test.js
@@ -1,0 +1,41 @@
+import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | sanity check', {
+  integration: true
+});
+
+test('it targets the parent', function(assert) {
+  this.render(hbs`
+    <div id='parent' style='height: 50px; width: 100%;'>
+      {{#ember-popper-targeting-parent class='popper-element' placement='bottom'}}
+        template block text
+      {{/ember-popper-targeting-parent}}
+    </div>
+  `);
+
+  const parent = document.getElementById('parent');
+  const popper = document.querySelector('.popper-element');
+
+  return wait().then(() => {
+    assert.equal(parent.getBoundingClientRect().bottom,
+                 popper.getBoundingClientRect().top);
+
+  });
+});
+
+test('registerAPI returns the parent', function(assert) {
+  this.on('registerAPI', ({ popperTarget }) => {
+    const parent = document.querySelector('.parent');
+    assert.equal(popperTarget, parent);
+  });
+
+  this.render(hbs`
+    <div class='parent'>
+      {{#ember-popper-targeting-parent class='popper-element' registerAPI='registerAPI'}}
+        template block text
+      {{/ember-popper-targeting-parent}}
+    </div>
+  `);
+});

--- a/tests/integration/components/ember-popper/action-test.js
+++ b/tests/integration/components/ember-popper/action-test.js
@@ -5,23 +5,24 @@ import wait from 'ember-test-helpers/wait';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 if (hasEmberVersion(1, 13)) {
-  moduleForComponent('ember-popper', 'Integration | Component | actions', {
+  moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | actions', {
     integration: true
   });
 
   test('it calls onCreate', function(assert) {
     assert.expect(2);
+
     let called = 0;
-    const action = (data) => {
+    this.on('create', (data) => {
       called++;
       assert.ok(data && data.instance, 'onCreate action is called with dataObject');
-    };
-    this.on('create', action);
+    });
+
     this.render(hbs`
-    {{#ember-popper onCreate=(action "create")}}
-      template block text
-    {{/ember-popper}}
-  `);
+      {{#ember-popper-targeting-parent onCreate=(action "create")}}
+        template block text
+      {{/ember-popper-targeting-parent}}
+    `);
 
     return wait()
       .then(() => assert.equal(called, 1, 'onCreate action has been called'));
@@ -29,24 +30,24 @@ if (hasEmberVersion(1, 13)) {
 
   test('it calls onUpdate', function(assert) {
     assert.expect(2);
+
     let called = 0;
-    const action = (data) => {
+    this.on('update', (data) => {
       called++;
       assert.ok(data && data.instance, 'onUpdate action is called with dataObject');
-    };
-    this.on('update', action);
+    });
+
     this.render(hbs`
-    {{#ember-popper onUpdate=(action "update")}}
-      template block text
-    {{/ember-popper}}
-  `);
+      {{#ember-popper-targeting-parent onUpdate=(action "update")}}
+        template block text
+      {{/ember-popper-targeting-parent}}
+    `);
 
     return wait()
       .then(() => triggerEvent(document.querySelector('body'), 'scroll'))
       .then(() => wait())
       .then(() => {
         assert.equal(called, 1, 'onUpdate action has been called after event');
-        return wait();
       });
   });
 }

--- a/tests/integration/components/ember-popper/attributes-test.js
+++ b/tests/integration/components/ember-popper/attributes-test.js
@@ -2,16 +2,16 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { find } from 'ember-native-dom-helpers';
 
-moduleForComponent('ember-popper', 'Integration | Component | attributes', {
+moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | attributes', {
   integration: true
 });
 
 test('id is bound correctly', function(assert) {
   this.render(hbs`
     <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100%;'>
-      {{#ember-popper placement='top' id='foo'}}
+      {{#ember-popper-targeting-parent placement='top' id='foo'}}
         test
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 
@@ -21,9 +21,9 @@ test('id is bound correctly', function(assert) {
 test('class is bound correctly', function(assert) {
   this.render(hbs`
     <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100%;'>
-      {{#ember-popper placement='top' class='foo'}}
+      {{#ember-popper-targeting-parent placement='top' class='foo'}}
         test
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 
@@ -33,9 +33,9 @@ test('class is bound correctly', function(assert) {
 test('role is bound correctly', function(assert) {
   this.render(hbs`
     <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100%;'>
-      {{#ember-popper id='foo' placement='top' ariaRole='tooltip'}}
+      {{#ember-popper-targeting-parent id='foo' placement='top' ariaRole='tooltip'}}
         test
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 

--- a/tests/integration/components/ember-popper/events-enabled-test.js
+++ b/tests/integration/components/ember-popper/events-enabled-test.js
@@ -3,20 +3,20 @@ import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import { triggerEvent } from 'ember-native-dom-helpers';
 
-moduleForComponent('ember-popper', 'Integration | Component | eventsEnabled', {
+moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | eventsEnabled', {
   integration: true
 });
 
 test('sets eventsEnabled in the Popper instance', function(assert) {
   this.render(hbs`
     <div class='parent' style='height: 100px; width: 100%;'>
-      {{#ember-popper placement='bottom' class='events-enabled'}}
+      {{#ember-popper-targeting-parent placement='bottom' class='events-enabled'}}
         eventsEnabled test
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
 
-      {{#ember-popper eventsEnabled=false placement='bottom' class='events-disabled'}}
+      {{#ember-popper-targeting-parent eventsEnabled=false placement='bottom' class='events-disabled'}}
         eventsEnabled test
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 
@@ -39,24 +39,23 @@ test('sets eventsEnabled in the Popper instance', function(assert) {
 
     parent.style.height = '200px';
 
-    // Trigger multiple scroll events and a wait because we need to make sure the update completes.
-    return triggerEvent(document.querySelector('body'), 'scroll').then(() => {
-      return triggerEvent(document.querySelector('body'), 'scroll').then(() => {
-        return wait().then(() => {
-          // Sanity check
-          assert.notEqual(initialBottomOfParent,
-                          parent.getBoundingClientRect().bottom,
-                          'the parent moved');
+    // Wait for repaint from style change, then trigger scroll
+    return wait()
+      .then(() => triggerEvent(document.querySelector('body'), 'scroll'))
+      .then(wait)
+      .then(() => {
+        // Sanity check
+        assert.notEqual(initialBottomOfParent,
+                        parent.getBoundingClientRect().bottom,
+                        'the parent moved');
 
-          assert.equal(eventsEnabledPopper.getBoundingClientRect().top,
-                       parent.getBoundingClientRect().bottom,
-                       'events enabled poppers move on scroll');
+        assert.equal(eventsEnabledPopper.getBoundingClientRect().top,
+                     parent.getBoundingClientRect().bottom,
+                     'events enabled poppers move on scroll');
 
-          assert.equal(eventsDisabledPopper.getBoundingClientRect().top,
-                       eventsDisabledInitialPosition,
-                       "events not enabled poppers don't move on scroll");
-        });
+        assert.equal(eventsDisabledPopper.getBoundingClientRect().top,
+                     eventsDisabledInitialPosition,
+                     "events not enabled poppers don't move on scroll");
       });
-    });
   });
 });

--- a/tests/integration/components/ember-popper/modifiers-test.js
+++ b/tests/integration/components/ember-popper/modifiers-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-moduleForComponent('ember-popper', 'Integration | Component | modifiers', {
+moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | modifiers', {
   integration: true
 });
 
@@ -12,15 +12,15 @@ test('it passes the modifiers to the Popper.js instance', function(assert) {
 
   this.render(hbs`
     <div class='parent'>
-      {{#ember-popper class='arrow-enabled' modifiers=arrowsEnabledModifier}}
+      {{#ember-popper-targeting-parent class='arrow-enabled' modifiers=arrowsEnabledModifier}}
         modifiers test
         <div class='popper-arrow' x-arrow></div>
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
 
-      {{#ember-popper class='arrow-disabled' modifiers=arrowsDisabledModifier}}
+      {{#ember-popper-targeting-parent class='arrow-disabled' modifiers=arrowsDisabledModifier}}
         modifiers test
         <div class='popper-arrow' x-arrow></div>
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 

--- a/tests/integration/components/ember-popper/placement-test.js
+++ b/tests/integration/components/ember-popper/placement-test.js
@@ -1,25 +1,25 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('ember-popper', 'Integration | Component | placement', {
+moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | placement', {
   integration: true
 });
 
 test('it places the popper appropriately', function(assert) {
   this.render(hbs`
     <div>
-      {{#ember-popper class='left-plz' placement="left"}}
+      {{#ember-popper-targeting-parent class='left-plz' placement="left"}}
         template block text
-      {{/ember-popper}}
-      {{#ember-popper class='right-plz' placement="right"}}
+      {{/ember-popper-targeting-parent}}
+      {{#ember-popper-targeting-parent class='right-plz' placement="right"}}
         template block text
-      {{/ember-popper}}
-      {{#ember-popper class='top-plz' placement="top"}}
+      {{/ember-popper-targeting-parent}}
+      {{#ember-popper-targeting-parent class='top-plz' placement="top"}}
         template block text
-      {{/ember-popper}}
-      {{#ember-popper class='bottom-plz' placement="bottom"}}
+      {{/ember-popper-targeting-parent}}
+      {{#ember-popper-targeting-parent class='bottom-plz' placement="bottom"}}
         template block text
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 

--- a/tests/integration/components/ember-popper/render-in-place-test.js
+++ b/tests/integration/components/ember-popper/render-in-place-test.js
@@ -1,16 +1,16 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('ember-popper', 'Integration | Component | renderInPlace', {
+moduleForComponent('ember-popper-targeting-parent', 'Integration | Component | renderInPlace', {
   integration: true
 });
 
 test('false: renders in the body', function(assert) {
   this.render(hbs`
     <div>
-      {{#ember-popper class='hello' renderInPlace=false}}
+      {{#ember-popper-targeting-parent class='hello' renderInPlace=false}}
         template block text
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 
@@ -29,9 +29,9 @@ test('false with an explicit popperContainer: renders in the popperContainer', f
     </div>
 
     <div>
-      {{#ember-popper class='hello' popperContainer='.poppers-plz' renderInPlace=false}}
+      {{#ember-popper-targeting-parent class='hello' popperContainer='.poppers-plz' renderInPlace=false}}
         template block text
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 
@@ -47,9 +47,9 @@ test('false with an explicit popperContainer: renders in the popperContainer', f
 test('true: renders in place', function(assert) {
   this.render(hbs`
     <div class='parent'>
-      {{#ember-popper class='hello' renderInPlace=true}}
+      {{#ember-popper-targeting-parent class='hello' renderInPlace=true}}
         template block text
-      {{/ember-popper}}
+      {{/ember-popper-targeting-parent}}
     </div>
   `);
 

--- a/tests/integration/components/ember-popper/target-test.js
+++ b/tests/integration/components/ember-popper/target-test.js
@@ -6,41 +6,38 @@ moduleForComponent('ember-popper', 'Integration | Component | target', {
   integration: true
 });
 
-test('undefined popperTarget: it targets the parent', function(assert) {
+test('it targets the explicit target', function(assert) {
+  // wait to show the ember-popper until we have set the popperTarget property.
+  this.set('show', false);
+
   this.render(hbs`
-    <div class='parent' style='height: 50px; width: 100%;'>
-      {{#ember-popper class='popper-element' placement='bottom'}}
+    <div id="target">
+      the target
+    </div>
+
+    {{#if show}}
+      {{#ember-popper id='attachment' popperTarget=popperTarget}}
         template block text
       {{/ember-popper}}
-    </div>
+    {{/if}}
   `);
 
-  const parent = document.querySelector('.parent');
-  const popper = document.querySelector('.popper-element');
+  const popperTarget = document.getElementById('target');
+
+  this.set('popperTarget', popperTarget);
+
+  // Show the ember-popper-targeted now that we have a target to pass it
+  this.set('show', true);
+
+  const popper = document.getElementById('attachment');
+
+  assert.equal(popper.innerHTML.trim(), 'template block text');
+  assert.ok(popper.hasAttribute('x-placement'));
+
+  assert.equal(popper.parentElement, document.querySelector('.ember-application'));
 
   return wait().then(() => {
-    assert.equal(parent.getBoundingClientRect().bottom,
-                 popper.getBoundingClientRect().top);
-
-  });
-});
-
-test('explicit popperTarget: it targets the explicit target', function(assert) {
-  this.render(hbs`
-    <div class='parent' style='height: 50px; width: 100%;'>
-    </div>
-
-    {{#ember-popper class='popper-element' placement='top' popperTarget='.parent'}}
-      template block text
-    {{/ember-popper}}
-  `);
-
-  const parent = document.querySelector('.parent');
-  const popper = document.querySelector('.popper-element');
-
-  return wait().then(() => {
-    assert.equal(parent.getBoundingClientRect().bottom,
+    assert.equal(popperTarget.getBoundingClientRect().bottom,
                  popper.getBoundingClientRect().top);
   });
 });
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -2501,9 +2501,9 @@ ember-native-dom-event-dispatcher@^0.6.3:
   dependencies:
     ember-cli-babel "^6.4.1"
 
-ember-native-dom-helpers@^0.5.8:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.8.tgz#34635c891474c640a63c4c4cf95a491b250edd6c"
+ember-native-dom-helpers@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz#9c7172e4ddfa5dd86830c46a936e2f8eca3e5896"
   dependencies:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
Introduces a component that requires a target. This is particularly useful for consumers which implement lazy-rendering of the popper.

The explicitly-targeted ember-popper would allow addons like ember-attacher and ember-bootstrap to implement target-finding themselves (as is already done for ember-bootstrap), then pass the target along without redoing any of the work involved in finding the target.

Also includes some stability fixes for the brittle tests. I have a hunch that the way scroll events are handled may have gotten a lot less responsive, requiring us to wait multiple cycles to ensure the scroll event is fired to listeners and the subsequent RAF completes.