### PR TITLE
chore(deps): Update legacy shims and @argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/argument": "^0.8.3",
+    "@ember-decorators/argument": "^0.8.10",
     "@ember-decorators/babel-transforms": "^0.1.1",
     "babel-eslint": "^8.0.3",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
@@ -35,7 +35,7 @@
     "ember-cli-version-checker": "^2.1.0",
     "ember-compatibility-helpers": "^0.1.3",
     "ember-decorators": "^1.3.2",
-    "ember-legacy-class-transform": "^0.1.4",
+    "ember-legacy-class-shim": "^1.0.0",
     "ember-raf-scheduler": "^0.1.0",
     "fastboot-transform": "^0.1.0",
     "popper.js": "^1.12.9"

--- a/tests/integration/components/ember-popper/action-test.js
+++ b/tests/integration/components/ember-popper/action-test.js
@@ -43,7 +43,7 @@ if (hasEmberVersion(1, 13)) {
 
     return wait()
       .then(() => triggerEvent(document.querySelector('body'), 'scroll'))
-      .then(wait)
+      .then(() => wait())
       .then(() => {
         assert.equal(called, 1, 'onUpdate action has been called after event');
         return wait();

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,9 @@
 import Application from '../app';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import registerRAFWaiter from 'ember-raf-scheduler/test-support/register-waiter';
 
+registerRAFWaiter();
 setApplication(Application.create({ autoboot: false }));
 
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,9 +55,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@ember-decorators/argument@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.3.tgz#dd2f393ba7f50b46051d66fdef88076ae1fb170a"
+"@ember-decorators/argument@^0.8.10":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.10.tgz#c48af0c5c57b5ef3022eba1ce5797a18d1edb6eb"
   dependencies:
     babel-plugin-filter-imports "^1.1.1"
     broccoli-funnel "^2.0.1"
@@ -608,10 +608,6 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
   dependencies:
     semver "^5.3.0"
-
-babel-plugin-ember-legacy-class-constructor@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.4.tgz#dfe715b9bdb66f6c7e9eccc620137c03b3fa89e0"
 
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
   version "2.0.1"
@@ -2478,12 +2474,10 @@ ember-hash-helper-polyfill@^0.2.0:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^1.2.0"
 
-ember-legacy-class-transform@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.4.tgz#0dd588b8561a4d31c080d5d7ada64521365b3806"
+ember-legacy-class-shim@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-legacy-class-shim/-/ember-legacy-class-shim-1.0.0.tgz#569afce1419d3075e41b324fbf8195f6493e3396"
   dependencies:
-    babel-plugin-ember-legacy-class-constructor "^0.1.4"
-    ember-cli-babel "^6.3.0"
     ember-cli-version-checker "^2.0.0"
 
 ember-load-initializers@^1.0.0:


### PR DESCRIPTION
After some recent research we've been able to make the legacy class transforms and `@argument` more efficient overall, and more inline with the future version of ES classes. This PR bumps the dependencies to the most recent releases.