### PR TITLE
feat(api): support hidden attribute

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -24,6 +24,14 @@ export default class EmberPopperBase extends Component {
   eventsEnabled = true
 
   /**
+   * Whether the Popper element should be hidden. Use this and CSS for `[hidden]` instead of
+   * an `{{if}}` if you want to animate the Popper's entry and/or exit.
+   */
+  @argument({ defaultIfUndefined: false })
+  @type('boolean')
+  hidden = false
+
+  /**
    * Modifiers that will be merged into the Popper instance's options hash.
    * https://popper.js.org/popper-documentation.html#Popper.DEFAULTS
    */

--- a/addon/templates/components/ember-popper-targeting-parent.hbs
+++ b/addon/templates/components/ember-popper-targeting-parent.hbs
@@ -7,7 +7,7 @@
       on the document body, giving it the highest default z-index value. --}}
 {{#maybe-in-element _popperContainer renderInPlace}}
 {{!-- Add a wrapper around the yielded block so we have something for the Popper to target --}}
-  <div id={{id}} class={{class}} role={{ariaRole}}>
+  <div id={{id}} class={{class}} hidden={{hidden}} role={{ariaRole}}>
     {{yield (hash
       disableEventListeners=(action 'disableEventListeners')
       enableEventListeners=(action 'enableEventListeners')

--- a/addon/templates/components/ember-popper.hbs
+++ b/addon/templates/components/ember-popper.hbs
@@ -5,7 +5,7 @@
       on the document body, giving it the highest default z-index value. --}}
 {{#maybe-in-element _popperContainer renderInPlace}}
   {{!-- Add a wrapper around the yielded block so we have something for the Popper to target --}}
-  <div id={{id}} class={{class}} role={{ariaRole}}>
+  <div id={{id}} class={{class}} hidden={{hidden}} role={{ariaRole}}>
     {{yield (hash
       disableEventListeners=(action 'disableEventListeners')
       enableEventListeners=(action 'enableEventListeners')

--- a/tests/integration/components/ember-popper-targeting-parent-test.js
+++ b/tests/integration/components/ember-popper-targeting-parent-test.js
@@ -25,6 +25,36 @@ test('it targets the parent', function(assert) {
   });
 });
 
+test('it passes ariaRole as role', async function(assert) {
+  await this.render(hbs`
+    <div id='parent'>
+      {{#ember-popper-targeting-parent ariaRole='tooltip' id='popper-element'}}
+        The tooltip
+      {{/ember-popper-targeting-parent}}
+    </div>
+  `);
+
+  const tooltip = document.querySelector('#popper-element');
+  assert.equal(tooltip.getAttribute('role'), 'tooltip');
+});
+
+test('it passes hidden', async function(assert) {
+  this.set('hidden', false);
+
+  await this.render(hbs`
+    <div id='parent'>
+      {{#ember-popper-targeting-parent id='popper-element' hidden=hidden}}
+        A possibly hidden popper
+      {{/ember-popper-targeting-parent}}
+    </div>
+  `);
+
+  const tooltip = document.querySelector('#popper-element');
+  assert.equal(tooltip.hidden, false);
+  this.set('hidden', true);
+  assert.equal(tooltip.hidden, true);
+});
+
 test('registerAPI returns the parent', function(assert) {
   this.on('registerAPI', ({ popperTarget }) => {
     const parent = document.querySelector('.parent');

--- a/tests/integration/components/ember-popper/attributes-test.js
+++ b/tests/integration/components/ember-popper/attributes-test.js
@@ -30,6 +30,18 @@ test('class is bound correctly', function(assert) {
   assert.ok(find('.foo'), 'class attribute bound correctly');
 });
 
+test('hidden is bound correctly', async function(assert) {
+  await this.render(hbs`
+    <div class='parent'>
+      {{#ember-popper-targeting-parent id='foo' hidden=true}}
+        test
+      {{/ember-popper-targeting-parent}}
+    </div>
+  `);
+
+  assert.equal(find('#foo').hidden, true, 'hidden attribute bound correctly');
+});
+
 test('role is bound correctly', function(assert) {
   this.render(hbs`
     <div class='parent' style='position: fixed; bottom: 0; height: 100px; width: 100%;'>


### PR DESCRIPTION
`{{ember-popper}}` and `{{ember-popper-targeting-parent}}` both accept a `hidden=[true|false]` attribute. That attribute is passed down to the Popper element.

`[hidden]` is an HTML5 standard attribute with good browser support. It's both semantically meaningful and a good way to support CSS visibility transitions.