### PR TITLE
Move `babel-eslint` to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@ember-decorators/argument": "^0.8.13",
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "babel-eslint": "^8.0.3",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "ember-cli-babel": "^6.10.0",
     "ember-cli-htmlbars": "^2.0.3",
@@ -42,6 +41,7 @@
     "popper.js": "^1.14.1"
   },
   "devDependencies": {
+    "babel-eslint": "^8.0.3",
     "broccoli-asset-rev": "^2.6.0",
     "ember-cli": "~3.1.0-beta.1",
     "ember-cli-dependency-checker": "^2.1.0",


### PR DESCRIPTION
This dependency is not used in prod, so there is no need to fetch it for everyone using this addon.