### PR TITLE
Call `registerAPI()` action directly instead of using the deprecated `sendAction()` method

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -252,7 +252,7 @@ export default class EmberPopperBase extends Component {
       // Execute the registerAPI hook last to ensure the Popper is initialized on the target
       if (this.get('registerAPI') !== null) {
         /* eslint-disable ember/closure-actions */
-        this.sendAction('registerAPI', this._getPublicAPI());
+        this.get('registerAPI')(this._getPublicAPI());
       }
     }
   }

--- a/tests/integration/components/ember-popper-targeting-parent-test.js
+++ b/tests/integration/components/ember-popper-targeting-parent-test.js
@@ -63,7 +63,7 @@ test('registerAPI returns the parent', function(assert) {
 
   this.render(hbs`
     <div class='parent'>
-      {{#ember-popper-targeting-parent class='popper-element' registerAPI='registerAPI'}}
+      {{#ember-popper-targeting-parent class='popper-element' registerAPI=(action 'registerAPI')}}
         template block text
       {{/ember-popper-targeting-parent}}
     </div>


### PR DESCRIPTION
Resolves https://github.com/kybishop/ember-popper/issues/91

/cc @kybishop @pzuraq 