### PR TITLE
Only destroy the Popper instance if it has been created

### DIFF
--- a/addon/components/ember-popper-base.js
+++ b/addon/components/ember-popper-base.js
@@ -165,7 +165,9 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    this._popper.destroy();
+    if (this._popper !== null) {
+      this._popper.destroy();
+    }
     raf.forget(this._updateRAF);
   },
 


### PR DESCRIPTION
With [ember-ref-modifier](https://github.com/lifeart/ember-ref-modifier) v1, the ref modifier operates asynchronously, so our test suite started erroring with calling `destroy()` on `undefined` because the `willDestroyElement` lifecycle hook makes the assumption that the Popper instance got created synchronously when the component was rendered.

I'm assuming our test suite was rendering and destroying Popper instances quickly enough in some cases where the ref modifier hadn't yet registered the popper element.

I added a similar check to what is called within the `_updatePopper()` method to make sure the popper instance exists before attempting to destroy it.