### PR TITLE
Update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-htmlbars": "^4.2.0",
     "ember-cli-node-assets": "^0.2.2",
     "ember-in-element-polyfill": "^1.0.0",
-    "ember-raf-scheduler": "^0.1.0",
+    "ember-raf-scheduler": "^0.2.0",
     "fastboot-transform": "^0.1.0",
     "popper.js": "^1.14.1"
   },


### PR DESCRIPTION
This is a pull request to upgrade ember-raf-scheduler to the latest version so it uses an update version of ember-cli-babel. Currently I get this deprecation message when building ember-bootstrap.

```
The following outdated versions are found in your project:

* ember-cli-babel@6.18.0, currently used by:
  * ember-raf-scheduler@0.1.0
    * Depends on ember-cli-babel@^6.6.0
    * Added by ember-bootstrap@4.9.0 > ember-popper@0.11.3
```

Let me know if I need to do anything else for this PR to be included.