### PR TITLE
name correct addon in deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-DEPRECATED: use [ember-style-modifier](https://github.com/adopted-ember-addons/ember-popper-modifier) or [ember-popperjs](https://github.com/NullVoxPopuli/ember-popperjs)
+DEPRECATED: use [ember-popper-modifier](https://github.com/adopted-ember-addons/ember-popper-modifier) or [ember-popperjs](https://github.com/NullVoxPopuli/ember-popperjs)


### PR DESCRIPTION
Seems autocorrect had changed it to wrong addon name in my original issue. I haven't noticed. And it got copied over here.